### PR TITLE
Split codecs by space and comma instead of just comma

### DIFF
--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -105,7 +105,7 @@ class PlaylistLoader extends EventHandler {
 
       var codecs = attrs.CODECS;
       if(codecs) {
-        codecs = codecs.split(',');
+        codecs = codecs.split(/[ ,]+/);
         for (let i = 0; i < codecs.length; i++) {
           const codec = codecs[i];
           if (codec.indexOf('avc1') !== -1) {


### PR DESCRIPTION
Stream: playertest.longtailvideo.com/adaptive/bunny/manifest.m3u

Codecs in this stream are separated by spaces, causing hls.js to report that there is no audio stream. This results in the buffer-controller expecting to create only one source buffer. However, there are two pending tracks (audio and video). The mismatch between pending tracks expected number of source buffers causes no source buffers to be created at all (https://github.com/jwplayer/hls.js/blob/master/src/controller/buffer-controller.js#L123).

JW7-3394