### PR TITLE
Ignore ID3 Timestamp data if we've received segments without it

### DIFF
--- a/src/demux/aacdemuxer.js
+++ b/src/demux/aacdemuxer.js
@@ -37,7 +37,7 @@ import ID3 from '../demux/id3';
   push(data, audioCodec, videoCodec, timeOffset, cc, level, sn, duration,accurateTimeOffset) {
     var track,
         id3 = new ID3(data),
-        pts = 90 * id3.timeStamp || timeOffset * 90000,
+        pts = timeOffset * 90000,
         config, frameLength, frameDuration, frameIndex, offset, headerLength, stamp, len, aacSample;
 
     let contiguous = false;


### PR DESCRIPTION
Remove ID3 dependencies when playing back audio streams.  They occasionally have segments which include timeStamp data in its ID3.  This causes the stream to write audio as the wrong time and appear to stall.  Instead, we will simply write the audio in at the timeOffset that is provided into the stream.

JW7-3452