### PR TITLE
Use ID3 Timestamp information only when parsing alternate audio renditions

### DIFF
--- a/src/demux/aacdemuxer.js
+++ b/src/demux/aacdemuxer.js
@@ -13,7 +13,8 @@ import ID3 from '../demux/id3';
     this.remuxerClass = remuxerClass;
     this.config = config;
     this.remuxer = new this.remuxerClass(observer,id, config);
-    // 'audio' demuxer is used for multitrack audio and requires the use of timestamps to sync audio with video
+    // id === 'main' when the demuxer is used to play an audio only stream and requires AAC files placed back-to-back in the order they are received.
+    // id === 'audio' when the demuxer is used for multitrack audio and requires the use of timestamps to sync audio with video.
     this.useTimeStamp = id === 'audio';
     this.insertDiscontinuity();
   }

--- a/src/demux/aacdemuxer.js
+++ b/src/demux/aacdemuxer.js
@@ -13,6 +13,8 @@ import ID3 from '../demux/id3';
     this.remuxerClass = remuxerClass;
     this.config = config;
     this.remuxer = new this.remuxerClass(observer,id, config);
+    // 'audio' demuxer is used for multitrack audio and requires the use of timestamps to sync audio with video
+    this.useTimeStamp = id === 'audio';
     this.insertDiscontinuity();
   }
 
@@ -37,8 +39,10 @@ import ID3 from '../demux/id3';
   push(data, audioCodec, videoCodec, timeOffset, cc, level, sn, duration,accurateTimeOffset) {
     var track,
         id3 = new ID3(data),
-        pts = 90 * id3.timeStamp || timeOffset * 90000,
-        config, frameLength, frameDuration, frameIndex, offset, headerLength, stamp, len, aacSample;
+        pts, config, frameLength, frameDuration, frameIndex, offset, headerLength, stamp, len, aacSample;
+
+    // Use ID3 Timestamp if needed, as in v4 audio tracks.  Otherwise, concat AAC audio in the order it comes in.
+    pts = (this.useTimeStamp) ? 90 * id3.timeStamp : timeOffset * 90000;
 
     let contiguous = false;
     if (cc !== this.lastCC) {


### PR DESCRIPTION
In order to support AAC audio only streams and v4 audio tracks, the AACDemuxer can get PTS for segments in two different ways.  When playing back v4 audio streams, we need to use ID3 data to set the PTS of the segments correctly.  In this situation, the AADDemxuer is initialized with an id of 'audio' and therefore use the timeStamp from the ID3 data to set the PTS.  Otherwise, we want to ignore the timestamp value because when playing back a single audio track, we expect to be able to append audio segments one after another in order to get the expected playback.

JW7-3452