### PR TITLE
Reuse textTracks with the same label 

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -159,18 +159,28 @@ class TimelineController extends EventHandler {
   }
 
   onManifestLoaded(data) {
-    // TODO: actually remove the tracks from the media object.
     this.textTracks = [];
 
     this.unparsedVttFrags = [];
     this.initPTS = undefined;
 
-    // TODO: maybe enable WebVTT if "forced"?
     if(this.config.enableWebVTT) {
       this.tracks = data.subtitles || [];
+      const inUseTracks = this.video.textTracks;
 
-      this.tracks.forEach((track) => {
-        const textTrack = this.createTextTrack('subtitles', track.name, track.lang);
+      this.tracks.forEach((track, index) => {
+        let textTrack;
+        const inUseTrack = inUseTracks[index];
+        if (inUseTrack) {
+          if (inUseTrack.label === track.name) {
+            textTrack = inUseTrack;
+          } else {
+            inUseTrack.mode = 'disabled';
+            inUseTrack.default = false;
+          }
+        } else {
+          textTrack = this.createTextTrack('subtitles', track.name, track.lang);
+        }
         textTrack.mode = track.default ? 'showing' : 'hidden';
         this.textTracks.push(textTrack);
       });

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -171,13 +171,8 @@ class TimelineController extends EventHandler {
       this.tracks.forEach((track, index) => {
         let textTrack;
         const inUseTrack = inUseTracks[index];
-        if (inUseTrack) {
-          if (inUseTrack.label === track.name) {
-            textTrack = inUseTrack;
-          } else {
-            inUseTrack.mode = 'disabled';
-            inUseTrack.default = false;
-          }
+        if (inUseTrack && inUseTrack.label === track.name) {
+          textTrack = inUseTrack;
         } else {
           textTrack = this.createTextTrack('subtitles', track.name, track.lang);
         }


### PR DESCRIPTION
This PR only fixes duplicate captions when we come back from an ad. Instead of adding duplicate tracks, reuse existing ones.
JW7-3511