### PR TITLE
Create maps to translate PTS values and Discontinuity Sequence Ids to align content

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ All HLS resources must be delivered with [CORS headers](https://developer.mozill
   - `#EXT-X-MEDIA-SEQUENCE`
   - `#EXT-X-TARGETDURATION`
   - `#EXT-X-DISCONTINUITY`
+  - `#EXT-X-DISCONTINUITY-SEQUENCE`  
   - `#EXT-X-BYTERANGE`
   - `#EXT-X-KEY` (https://tools.ietf.org/html/draft-pantos-http-live-streaming-08#section-3.4.4)
   - `#EXT-X-PROGRAM-DATE-TIME` (https://tools.ietf.org/html/draft-pantos-http-live-streaming-18#section-4.3.2.6)

--- a/src/demux/aacdemuxer.js
+++ b/src/demux/aacdemuxer.js
@@ -111,7 +111,7 @@ import ID3 from '../demux/id3';
       }
     }
     var id3Track = (id3.payload) ? { samples : [ { pts: pts, dts : pts, unit : id3.payload} ] } : { samples: [] };
-    this.remuxer.remux(level, sn , this._aacTrack, {samples : []}, id3Track, { samples: [] }, timeOffset, contiguous,accurateTimeOffset);
+    this.remuxer.remux(level, sn, this._aacTrack, {samples : []}, id3Track, { samples: [] }, timeOffset, contiguous, accurateTimeOffset, this.lastCC);
   }
 
   destroy() {

--- a/src/demux/tsdemuxer.js
+++ b/src/demux/tsdemuxer.js
@@ -267,7 +267,7 @@
     };},{len : 0, nbNalu : 0});
      avcTrack.len = trackData.len;
      avcTrack.nbNalu = trackData.nbNalu;
-    this.remuxer.remux(level, sn, this._aacTrack, this._avcTrack, this._id3Track, this._txtTrack, timeOffset, this.contiguous, this.accurateTimeOffset, data);
+    this.remuxer.remux(level, sn, this._aacTrack, this._avcTrack, this._id3Track, this._txtTrack, timeOffset, this.contiguous, this.accurateTimeOffset, this.lastCC, data);
   }
 
   destroy() {

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -219,7 +219,7 @@ class PlaylistLoader extends EventHandler {
         byteRangeStartOffset = null,
         tagList = [];
 
-    regexp = /(?:(?:#(EXTM3U))|(?:#EXT-X-(PLAYLIST-TYPE):(.+))|(?:#EXT-X-(MEDIA-SEQUENCE): *(\d+))|(?:#EXT-X-(TARGETDURATION): *(\d+))|(?:#EXT-X-(KEY):(.+))|(?:#EXT-X-(START):(.+))|(?:#EXT(INF): *(\d+(?:\.\d+)?)(?:,(.*))?)|(?:(?!#)()(\S.+))|(?:#EXT-X-(BYTERANGE): *(\d+(?:@\d+(?:\.\d+)?)?)|(?:#EXT-X-(ENDLIST))|(?:#EXT-X-(DIS)CONTINUITY))|(?:#EXT-X-(PROGRAM-DATE-TIME):(.+))|(?:#EXT-X-(VERSION):(\d+))|(?:(#)(.*):(.*))|(?:(#)(.*)))(?:.*)\r?\n?/g;
+    regexp = /(?:(?:#(EXTM3U))|(?:#EXT-X-(PLAYLIST-TYPE):(.+))|(?:#EXT-X-(MEDIA-SEQUENCE): *(\d+))|(?:#EXT-X-(TARGETDURATION): *(\d+))|(?:#EXT-X-(KEY):(.+))|(?:#EXT-X-(START):(.+))|(?:#EXT(INF): *(\d+(?:\.\d+)?)(?:,(.*))?)|(?:(?!#)()(\S.+))|(?:#EXT-X-(BYTERANGE): *(\d+(?:@\d+(?:\.\d+)?)?)|(?:#EXT-X-(ENDLIST))|(?:#EXT-X-(DISCONTINUITY-SEQ)UENCE:(\d+))|(?:#EXT-X-(DIS)CONTINUITY))|(?:#EXT-X-(PROGRAM-DATE-TIME):(.+))|(?:#EXT-X-(VERSION):(\d+))|(?:(#)(.*):(.*))|(?:(#)(.*)))(?:.*)\r?\n?/g;
     while ((result = regexp.exec(string)) !== null) {
       result.shift();
       result = result.filter(function(n) { return (n !== undefined); });
@@ -244,6 +244,9 @@ class PlaylistLoader extends EventHandler {
         case 'DIS':
           cc++;
           tagList.push(result);
+          break;
+        case 'DISCONTINUITY-SEQ':
+          cc = parseInt(result[1]);
           break;
         case 'BYTERANGE':
           var params = result[1].split('@');

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -38,28 +38,28 @@ class MP4Remuxer {
   }
 
   remux(level, sn, audioTrack, videoTrack, id3Track, textTrack, timeOffset, contiguous, accurateTimeOffset, cc) {
-    var switchedLevels = this.level !== level,
-        referencePTS = [videoTrack, audioTrack].reduce((value, track) => (value >= 0) ? value : (track.samples && track.samples.length) ? track.samples[0].pts : -1, -1);
+
+    let referencePTS = [videoTrack, audioTrack].reduce((value, track) => (value >= 0) ? value : (track.samples && track.samples.length) ? track.samples[0].pts : -1, -1);
+    if (referencePTS > -1) {
+      var map = this.discontinuityMap[cc];
+      if (!map) {
+        map = this.discontinuityMap[cc] = {
+          pts: referencePTS,
+          timeOffset: timeOffset
+        };
+        logger.log(`First instance of discontinuity sequence ${cc}, created a discontinuity map. pts ${referencePTS} timeOffset ${timeOffset}`);
+      }
+      if (this.level !== level && referencePTS !== map.pts) {
+        // Set the correct offset for where the segment will be written for the upcoming set of fragments based on the PTS
+        let previousTimeOffset = timeOffset;
+        timeOffset = ((referencePTS - map.pts) / 90000) + map.timeOffset;
+
+        logger.log(`Mapping PTS of ${referencePTS} with offset ${previousTimeOffset.toFixed(3)} to start at ${timeOffset.toFixed(3)} for discontinuity sequence ${cc}.`);
+      }
+    }
 
     this.level = level;
     this.sn = sn;
-
-    if (!this.discontinuityMap[cc]) {
-      this.discontinuityMap[cc] = {
-        pts: referencePTS,
-        timeOffset: timeOffset
-      };
-      logger.log(`First instance of discontinuity sequence ${cc}, created a discontinuity map. ${this.discontinuityMap[cc]}`);
-    }
-
-    if (switchedLevels) {
-      var map = this.discontinuityMap[cc];
-
-      // Set the correct offset for where the segment will be written for the upcoming set of fragments based on the PTS
-      timeOffset = ((referencePTS - map.pts) / 90000) + map.timeOffset;
-
-      logger.log(`Mapping PTS of ${referencePTS} for discontinuity sequence ${cc} to start being written at ${timeOffset.toFixed(3)}.`);
-    }
 
     // generate Init Segment if needed
     if (!this.ISGenerated) {

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -40,10 +40,8 @@ class MP4Remuxer {
   remux(level, sn, audioTrack, videoTrack, id3Track, textTrack, timeOffset, contiguous, accurateTimeOffset, cc) {
     var switchedLevels = this.level !== level,
         createdDiscontinuityMap = false,
-        sampleSources = [videoTrack, audioTrack, id3Track, textTrack],
-        referenceTrackIndex = sampleSources.findIndex( function(track) {
-          return (track.samples && track.samples.length) ? track.samples[0] : false;
-        }),
+        sampleSources = [videoTrack, audioTrack],
+        referenceTrackIndex = sampleSources.findIndex((track) => (track.samples && track.samples.length) ? track.samples[0] : false ),
         referencePTS = sampleSources[referenceTrackIndex].samples[0].pts;
 
     this.level = level;
@@ -64,6 +62,8 @@ class MP4Remuxer {
 
       // Set the correct offset for where the segment will be written for the upcoming set of fragments based on the PTS
       timeOffset = ((referencePTS - map.pts) / 90000) + map.timelineOffset;
+
+      logger.log(`Mapping PTS of ${referencePTS} for discontinuity sequence ${cc} to start being written at ${timeOffset.toFixed(3)}.`);
     }
 
     // generate Init Segment if needed

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -15,6 +15,7 @@ class MP4Remuxer {
     this.observer = observer;
     this.id = id;
     this.config = config;
+    this.discontinuityMap = {};
     this.ISGenerated = false;
     this.PES2MP4SCALEFACTOR = 4;
     this.PES_TIMESCALE = 90000;
@@ -36,9 +37,35 @@ class MP4Remuxer {
     this.ISGenerated = false;
   }
 
-  remux(level,sn,audioTrack,videoTrack,id3Track,textTrack,timeOffset, contiguous,accurateTimeOffset) {
+  remux(level, sn, audioTrack, videoTrack, id3Track, textTrack, timeOffset, contiguous, accurateTimeOffset, cc) {
+    var switchedLevels = this.level !== level,
+        createdDiscontinuityMap = false,
+        sampleSources = [videoTrack, audioTrack, id3Track, textTrack],
+        referenceTrackIndex = sampleSources.findIndex( function(track) {
+          return (track.samples && track.samples.length) ? track.samples[0] : false;
+        }),
+        referencePTS = sampleSources[referenceTrackIndex].samples[0].pts;
+
     this.level = level;
     this.sn = sn;
+
+    if (!this.discontinuityMap[cc]) {
+      this.discontinuityMap[cc] = {
+        discontinuitySequenceId: cc,
+        pts: referencePTS,
+        timelineOffset: timeOffset
+      };
+      logger.log(`First instance of discontinuity sequence ${cc}, created a discontinuity map. ${this.discontinuityMap[cc]}`);
+      createdDiscontinuityMap = true;
+    }
+
+    if (switchedLevels || createdDiscontinuityMap) {
+      var map = this.discontinuityMap[cc];
+
+      // Set the correct offset for where the segment will be written for the upcoming set of fragments based on the PTS
+      timeOffset = ((referencePTS - map.pts) / 90000) + map.timelineOffset;
+    }
+
     // generate Init Segment if needed
     if (!this.ISGenerated) {
       this.generateIS(audioTrack,videoTrack,timeOffset);

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -403,6 +403,34 @@ lo007ts`;
     assert.strictEqual(result.fragments[3].cc, 1); //continuity counter should increase around discontinuity
   });
 
+  it('parses correctly EXT-X-DISCONTINUITY-SEQUENCE and increases continuity counter', () => {
+    var level = `#EXTM3U
+#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:10
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-DISCONTINUITY-SEQUENCE:20
+#EXTINF:10,
+0001.ts
+#EXTINF:10,
+0002.ts
+#EXTINF:5,
+0003.ts
+#EXT-X-DISCONTINUITY
+#EXTINF:10,
+0005.ts
+#EXTINF:10,
+0006.ts
+#EXT-X-ENDLIST
+    `;
+    var result = new PlaylistLoader({on : function() { }}).parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8',0);
+    assert.strictEqual(result.fragments.length, 5);
+    assert.strictEqual(result.totalduration, 45);
+    assert.strictEqual(result.fragments[0].cc, 20);
+    assert.strictEqual(result.fragments[2].cc, 20);
+    assert.strictEqual(result.fragments[3].cc, 21); //continuity counter should increase around discontinuity
+  });
+
   it('parses manifest with one audio track', () => {
     var manifest = `#EXTM3U
 #EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="600k",LANGUAGE="eng",NAME="Audio",AUTOSELECT=YES,DEFAULT=YES,URI="/videos/ZakEbrahim_2014/audio/600k.m3u8?qr=true&preroll=Blank",BANDWIDTH=614400`;


### PR DESCRIPTION
This change creates maps that record what timeline time combinations of Discontinuity Sequence Ids and PTS value in order to let content write to the expected location in the stream.  This fixes issues when switching between quality levels in live streams which contain discontinuities by allowing the remuxer to successfully shift the information parsed out of a segment its position relative to the previous stream.  This allows stream to set the information that's stored about the level to have the correct time offset used by the stream controller to load subsequent fragments.  Without this, a newly loaded stream is assumed to start at a time of 0, and thus will stall for a very long time until the manifest loads enough segments that it will reach the current time in the video player.

JW7-3199