### PR TITLE
[Do not merge] Skip over 404 fragment proof of concept

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -274,7 +274,7 @@ $(document).ready(function() {
       $("#HlsStatus").text('loading ' + url);
        events = { url : url, t0 : performance.now(), load : [], buffer : [], video : [], level : [], bitrate : []};
        recoverDecodingErrorDate = recoverSwapAudioCodecDate = null;
-       hls = new Hls({debug:true, enableWorker : enableWorker, defaultAudioCodec : defaultAudioCodec});
+       hls = new Hls({debug:true, enableWorker : enableWorker, defaultAudioCodec : defaultAudioCodec });
        $("#HlsStatus").text('loading manifest and attaching video element...');
        hls.loadSource(url);
        hls.autoLevelCapping = levelCapping;
@@ -687,6 +687,7 @@ var lastSeekingIdx, lastStartPosition,lastDuration;
 
 var recoverDecodingErrorDate,recoverSwapAudioCodecDate;
 function handleMediaError() {
+    return;
   if(autoRecoverError) {
     var now = performance.now();
     if(!recoverDecodingErrorDate || (now - recoverDecodingErrorDate) > 3000) {


### PR DESCRIPTION
- Mark bad fragments with `skip`
- Load next SN if we would load a fragment with `skip`
- Jump to next buffered range if regardless of hole size if we've skipped a fragment

The problem with this PR is that we load the segment after the skip in a loop until we jump to the next buffered range


Notes:
- The binary search for fragments is causing problems here. The search is only looking at fragments up until (and including) the skip because the `bufferedEnd` has not been updated. This fixes itself after the fragment after the skip has been appended. It would be ideal to give this algorithm the `bufferedEnd` of the new time range.

@mangui