### PR TITLE
Align WebVTT cues based on the starting media sequence id

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -18,7 +18,8 @@ class TimelineController extends EventHandler {
                 Event.MANIFEST_LOADED,
                 Event.FRAG_LOADED,
                 Event.LEVEL_SWITCH,
-                Event.INIT_PTS_FOUND);
+                Event.INIT_PTS_FOUND,
+                Event.LEVEL_UPDATED);
 
     this.hls = hls;
     this.config = hls.config;
@@ -28,6 +29,8 @@ class TimelineController extends EventHandler {
     this.tracks = [];
     this.unparsedVttFrags = [];
     this.initPTS = undefined;
+    this.startSN = 0;
+    this.averageTargetDuration = 0;
 
     if (this.config.enableCEA708Captions)
     {
@@ -214,7 +217,7 @@ class TimelineController extends EventHandler {
           hls = this.hls;
 
         // Parse the WebVTT file contents.
-        WebVTTParser.parse(data.payload, this.initPTS, function (cues) {
+        WebVTTParser.parse(data.payload, this.initPTS, this.startSN, this.averageTargetDuration, function (cues) {
             // Add cues and trigger event with success true.
             cues.forEach(cue => {
               textTracks[data.frag.trackId].addCue(cue);
@@ -245,6 +248,11 @@ class TimelineController extends EventHandler {
         this.cea608Parser.addData(data.samples[i].pts, ccdatas);
       }
     }
+  }
+
+  onLevelUpdated(data) {
+    this.startSN = data.details.startSN;
+    this.averageTargetDuration = data.details.averagetargetduration;
   }
 
   extractCea608Data(byteArray) {


### PR DESCRIPTION
Live streams with embedded WebVTT are aligned using `X-TIMESTAMP-MAP`. The combination of the `LOCAL` time and the `MPEGTS` time should make it possible to derive the start/end times of a `VTTCue`. ([WebVTT Spec](https://tools.ietf.org/html/draft-pantos-http-live-streaming-20#section-3.5))

```
X-TIMESTAMP-MAP=LOCAL:<cue time>,MPEGTS:<MPEG-2 time>
e.g. X-TIMESTAMP-MAP=LOCAL:00:00:00.000,MPEGTS:900000
```

Some live streams seem to use their `EXT-X-MEDIA-SEQUENCE` for alignment of VTTCue according to the following:

`offset = EXT-X-MEDIA-SEQUENCE * SEGMENT LENGTH - SEGMENT LENGTH`

This change allows us to fall back to the above when the offset exceeds a day, which should never happen.

JW7-3514