### PR TITLE
[Comments Requested] Backtrack a segment when switching levels causes a gap

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1062,7 +1062,6 @@ class StreamController extends EventHandler {
             // Return back to the IDLE stater without updating the nextLoadPosition or appending to buffer
             // Causes findFragments to backtrack a segment and find the keyframe
             // Audio fragments arriving before video sets the nextLoadPosition, causing _findFragments to skip the backtracked fragment
-            logger.warn('Parsed video fragment with dropped frames, returning to idle without appending');
             frag.backtracked = true;
             this.nextLoadPosition = frag.startPTS;
             this.state = State.IDLE;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -404,10 +404,10 @@ class StreamController extends EventHandler {
     }
     if (foundFrag) {
       frag = foundFrag;
-      start = foundFrag.start;
       const curSNIdx = frag.sn - levelDetails.startSN;
+      const sameLevel = fragPrevious && frag.level === fragPrevious.level;
       //logger.log('find SN matching with pos:' +  bufferEnd + ':' + frag.sn);
-       if (fragPrevious && frag.level === fragPrevious.level && frag.sn === fragPrevious.sn) {
+       if (sameLevel && frag.sn === fragPrevious.sn) {
           if (frag.sn < levelDetails.endSN) {
             let deltaPTS = fragPrevious.deltaPTS;
             // if there is a significant delta between audio and video, larger than max allowed hole,
@@ -426,10 +426,10 @@ class StreamController extends EventHandler {
           } else {
             frag = null;
           }
-        } else if (frag.dropped) {
+        } else if (frag.dropped && !sameLevel) {
          // If a fragment has dropped frames and it's in a different level/sequence, load the previous fragment to try and find the keyframe
          // Reset the dropped count now since it won't be reset until we parse the fragment again, which prevents infinite backtracking on the same segment
-         logger.warn('Loaded fragment with dropped frames, backtracking 1 segment to find keyframe');
+         logger.warn('Loaded fragment with dropped frames, backtracking 1 segment to find a keyframe');
          frag.dropped = 0;
          const prev = fragments[curSNIdx - 1];
          if (prev) {
@@ -709,6 +709,7 @@ class StreamController extends EventHandler {
           if(level.details) {
             level.details.fragments.forEach(fragment => {
               fragment.loadCounter = undefined;
+              fragment.backtracked = undefined;
             });
           }
       });
@@ -1049,15 +1050,24 @@ class StreamController extends EventHandler {
 
       logger.log(`Parsed ${data.type},PTS:[${data.startPTS.toFixed(3)},${data.endPTS.toFixed(3)}],DTS:[${data.startDTS.toFixed(3)}/${data.endDTS.toFixed(3)}],nb:${data.nb},dropped:${data.dropped || 0}`);
 
+      // Detect gaps in a fragment  and try to fix it by finding a keyframe in the previous fragment (see _findFragments)
       if(data.type === 'video') {
         frag.dropped = data.dropped;
         if (frag.dropped) {
-          // Return back to the IDLE stater without updating the nextLoadPosition or appending to buffer
-          // Causes findFragments to backtrack a segment and find the keyframe
-          logger.warn('Parsed video fragment with dropped frames, returning to idle');
-          this.state = State.IDLE;
-          this.tick();
-          return;
+          if (!frag.backtracked) {
+            // Return back to the IDLE stater without updating the nextLoadPosition or appending to buffer
+            // Causes findFragments to backtrack a segment and find the keyframe
+            logger.warn('Parsed video fragment with dropped frames, returning to idle without appending');
+            frag.backtracked = true;
+            this.state = State.IDLE;
+            this.tick();
+            return;
+          } else {
+            logger.warn('Already backtracked on this fragment, appending with the gap');
+          }
+        } else {
+          // Only reset the backtracked flag if we've loaded the frag without any dropped frames
+          frag.backtracked = false;
         }
       }
 

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1059,7 +1059,7 @@ class StreamController extends EventHandler {
         frag.dropped = data.dropped;
         if (frag.dropped) {
           if (!frag.backtracked) {
-            // Return back to the IDLE stater without updating the nextLoadPosition or appending to buffer
+            // Return back to the IDLE state without appending to buffer
             // Causes findFragments to backtrack a segment and find the keyframe
             // Audio fragments arriving before video sets the nextLoadPosition, causing _findFragments to skip the backtracked fragment
             frag.backtracked = true;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -407,36 +407,37 @@ class StreamController extends EventHandler {
       start = foundFrag.start;
       const curSNIdx = frag.sn - levelDetails.startSN;
       //logger.log('find SN matching with pos:' +  bufferEnd + ':' + frag.sn);
-      if (fragPrevious) {
-         if (frag.level === fragPrevious.level && frag.sn === fragPrevious.sn) {
-            if (frag.sn < levelDetails.endSN) {
-              let deltaPTS = fragPrevious.deltaPTS;
-              // if there is a significant delta between audio and video, larger than max allowed hole,
-              // and if previous remuxed fragment did not start with a keyframe. (fragPrevious.dropped)
-              // let's try to load previous fragment again to get last keyframe
-              // then we will reload again current fragment (that way we should be able to fill the buffer hole ...)
-              if (deltaPTS && deltaPTS > config.maxBufferHole && fragPrevious.dropped && curSNIdx) {
-                frag = fragments[curSNIdx - 1];
-                logger.warn(`SN just loaded, with large PTS gap between audio and video, maybe frag is not starting with a keyframe ? load previous one to try to overcome this`);
-                // decrement previous frag load counter to avoid frag loop loading error when next fragment will get reloaded
-                fragPrevious.loadCounter--;
-              } else {
-                frag = fragments[curSNIdx + 1];
-                logger.log(`SN just loaded, load next one: ${frag.sn}`);
-              }
+       if (fragPrevious && frag.level === fragPrevious.level && frag.sn === fragPrevious.sn) {
+          if (frag.sn < levelDetails.endSN) {
+            let deltaPTS = fragPrevious.deltaPTS;
+            // if there is a significant delta between audio and video, larger than max allowed hole,
+            // and if previous remuxed fragment did not start with a keyframe. (fragPrevious.dropped)
+            // let's try to load previous fragment again to get last keyframe
+            // then we will reload again current fragment (that way we should be able to fill the buffer hole ...)
+            if (deltaPTS && deltaPTS > config.maxBufferHole && fragPrevious.dropped && curSNIdx) {
+              frag = fragments[curSNIdx - 1];
+              logger.warn(`SN just loaded, with large PTS gap between audio and video, maybe frag is not starting with a keyframe ? load previous one to try to overcome this`);
+              // decrement previous frag load counter to avoid frag loop loading error when next fragment will get reloaded
+              fragPrevious.loadCounter--;
             } else {
-              frag = null;
+              frag = fragments[curSNIdx + 1];
+              logger.log(`SN just loaded, load next one: ${frag.sn}`);
             }
-          } else if (frag.dropped) {
-           // If a fragment has dropped frames and it's in a different level/sequence, load the previous fragment to try and find the keyframe
-           // Reset the dropped count now since it won't be reset until we parse the fragment again, which prevents infinite backtracking on the same segment
-           logger.warn('Loaded fragment with dropped frames, backtracking 1 segment');
-           frag.dropped = 0;
-           frag = fragments[curSNIdx - 1];
-           fragPrevious.loadCounter--;
+          } else {
+            frag = null;
+          }
+        } else if (frag.dropped) {
+         // If a fragment has dropped frames and it's in a different level/sequence, load the previous fragment to try and find the keyframe
+         // Reset the dropped count now since it won't be reset until we parse the fragment again, which prevents infinite backtracking on the same segment
+         logger.warn('Loaded fragment with dropped frames, backtracking 1 segment to find keyframe');
+         frag.dropped = 0;
+         const prev = fragments[curSNIdx - 1];
+         if (prev) {
+           prev.loadCounter = Math.max(0, prev.loadCounter -= 1);
          }
-        }
+         frag = prev;
       }
+    }
     return frag;
   }
 


### PR DESCRIPTION
- `https://content.jwplatform.com/manifests/3FL1BWlU.m3u8` (2 segments, second drops)
- `https://content.jwplatform.com/manifests/THL4trVg.m3u8` (2 segments, second drops, audio drops)
- `http://streambox.fr/playlists/issue_004_2/index.m3u8` (3+ segments, first few drop, error seeking back to dropped range, plays fine in vanilla 0.6.12)
- `http://streambox.fr/playlists/issue_026/stream_multi.m3u8` (3+ segments, third drops, can seek back over range, (artifacts are "normal" in this stream), plays fine in vanilla 0.6.12)
- `https://content.jwplatform.com/manifests/XrUBAnE2.m3u8` (3 segments)
- `http://playertest.longtailvideo.com/adaptive/nih/playlist.m3u8` (3+ segments, 1 dropped frame on first segment, audio fragments arrive before video)

This seems to work well but I'd like feedback on the implementation/style. Also need additional test streams (3+ segments, backtracking in the middle, live).

Known Issues:
- ~Selecting `nextLevel` the same level in the stream tester multiple times causes a `fragLoopLoadingError` but playback is OK~ fixed


A good way to test for infinite loops is to mark every fragment as having dropped frames here:
https://github.com/jwplayer/hls.js/blob/master/src/demux/tsdemuxer.js#L424

JW7-3587