### PR TITLE
[Do not merge] Empty manifest handling

### DIFF
--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -222,6 +222,10 @@ class LevelController extends EventHandler {
         levelId = data.context.level;
         levelError = true;
         break;
+      case ErrorDetails.MANIFEST_EMPTY_ERROR:
+        levelId = data.context.level;
+        levelError = true;
+        break;
       default:
         break;
     }

--- a/src/errors.js
+++ b/src/errors.js
@@ -16,6 +16,8 @@ export const ErrorDetails = {
   MANIFEST_PARSING_ERROR: 'manifestParsingError',
   // Identifier for a manifest with only incompatible codecs error - data: { url : faulty URL, reason : error reason}
   MANIFEST_INCOMPATIBLE_CODECS_ERROR: 'manifestIncompatibleCodecsError',
+  //
+  MANIFEST_EMPTY_ERROR: 'manifestEmptyError',
   // Identifier for a level load error - data: { url : faulty URL, response : { code: error code, text: error text }}
   LEVEL_LOAD_ERROR: 'levelLoadError',
   // Identifier for a level load timeout - data: { url : faulty URL, response : { code: error code, text: error text }}

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -407,7 +407,7 @@ class PlaylistLoader extends EventHandler {
           }
           hls.trigger(Event.MANIFEST_LOADED, {levels, audioTracks, subtitles, url, stats});
         } else {
-          hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_PARSING_ERROR, fatal: true, url: url, reason: 'no level found in manifest'});
+          hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_EMPTY_ERROR, fatal: false, url: url, reason: 'no level found in manifest', context });
         }
       }
     } else {


### PR DESCRIPTION
Looks like redundant streams aren't working properly

What we want to do:
- If in auto mode and not on level 0, emergency downswitch to level 0 (& remove bad level from manifest?)
- If not in auto mode, error out