### PR TITLE
Captions fixes

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -56,7 +56,7 @@ class TimelineController extends EventHandler {
           }
           if (!self.addedCues['1' + startTime]) {
             self.Cues.newCue(self.textTrack1, startTime, endTime, screen);
-            self.addedCues[startTime] = endTime;
+            self.addedCues['1' + startTime] = endTime;
           }
         }
       };
@@ -85,7 +85,7 @@ class TimelineController extends EventHandler {
           }
           if (!self.addedCues['2' + startTime]) {
             self.Cues.newCue(self.textTrack2, startTime, endTime, screen);
-            self.addedCues[startTime] = endTime;
+            self.addedCues['2' + startTime] = endTime;
           }
         }
       };
@@ -184,8 +184,9 @@ class TimelineController extends EventHandler {
   onFragLoaded(data) {
     if (data.frag.type === 'main') {
       var sn = data.frag.sn;
-      // if this frag isn't contiguous, clear the parser so cues with bad start/end times aren't added to the textTrack
-      if (sn !== this.lastSn + 1) {
+      // if this frag isn't contiguous or if crossing a discontinuity zone,
+      // clear the parser so cues with bad start/end times aren't added to the textTrack
+      if (sn !== this.lastSn + 1 || this.lastDiscontinuity.cc !== data.frag.cc) {
         this.cea608Parser.reset();
       }
       this.lastSn = sn;

--- a/src/utils/vttparser.js
+++ b/src/utils/vttparser.js
@@ -246,9 +246,16 @@ VTTParser.prototype = {
       self.buffer += self.decoder.decode(data, {stream: true});
     }
 
+    function fixLineBreaks(input) {
+      return input.replace(/<br(?: \/)?>/gi, '\n');
+    }
+
     function collectNextLine() {
       var buffer = self.buffer;
       var pos = 0;
+
+      buffer = fixLineBreaks(buffer);
+
       while (pos < buffer.length && buffer[pos] !== '\r' && buffer[pos] !== '\n') {
         ++pos;
       }

--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -36,13 +36,13 @@ const WebVTTParser = {
 
         parser.oncue = function(cue) {
             // Adjust cue timing; clamp cues to start no earlier than - and drop cues that don't end after - 0 on timeline.
-          let offsetSecs = offsetMillis/1000;
+            let offsetSecs = offsetMillis/1000;
 
-          if (discontinuity.new) {
-            discontinuityOffset = discontinuity.start - offsetSecs;
-            discontinuity.new = false;
-          }
-          cue.startTime = discontinuityOffset + Math.max(0, cue.startTime + offsetSecs);
+            if (discontinuity.new) {
+              discontinuityOffset = discontinuity.start - offsetSecs;
+              discontinuity.new = false;
+            }
+            cue.startTime = discontinuityOffset + Math.max(0, cue.startTime + offsetSecs);
             cue.endTime += discontinuityOffset + offsetSecs;
 
             // Fix encoding of special characters. TODO: Test with all sorts of weird characters.


### PR DESCRIPTION
## Duplicate/Missing 608 captions cues

HLS.js cleared cues in the text track when:

media is detached (eg. between ad and video playback)
currentPts <= lastPts (eg. if we seeked backward or had to backtrack and reload a segment to prevent gaps in playback)
This caused a few issues:

Cues would get cleared on level changes, resulting in missing captions for periods of time during playback.
Cues would get cleared on seek. This also results in missing captions if you seek to a timeline position between the start/end time for a cue that was already parsed and added to the textTrack.
There'd be duplicate captions at the start of playback (side effect of a level switch) if you cleared your cache, started playback, then turned captions on a few seconds in.
With this approach, we keep track of the fragments we've added captions for based on the sequence number (sn). We also reset the parser when we encounter non-contiguous fragments to prevent captions from having incorrect start/end times on seek or level changes. The textTrack gets destroyed along with the video element when we destroy the hls.js instance between playlist items, so there's no longer a need to clear cues before reusing a track.

Caveat: these changes will have side effects for players that reuse the video element (and corresponding textTracks) when switching media. The HLS.js events docs seems to imply that detaching/reattaching media is the route to take for ad playback, but destroying media works better for switching media.

JW7-3616

---

## Misaligned subtitle cues

Some streams contain discontinuities caused by server-side ads stitched into the media manifests. In such cases, the WebVTT parser needs to take into account the time elapsed since the last discontinuity to determine the correct start and end times for VTTCues.

Also, HTML breaks are not supported according to the [WebVTT spec](https://w3c.github.io/webvtt/#introduction-multiple-lines). The VTT parser now replaces HTML breaks with line breaks before processing cues. 

JW7-3620