### PR TITLE
Fix 708 captions parsing in streams with discontinuities

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -184,9 +184,8 @@ class TimelineController extends EventHandler {
   onFragLoaded(data) {
     if (data.frag.type === 'main') {
       var sn = data.frag.sn;
-      // if this frag isn't contiguous or if crossing a discontinuity zone,
-      // clear the parser so cues with bad start/end times aren't added to the textTrack
-      if (sn !== this.lastSn + 1 || this.lastDiscontinuity.cc !== data.frag.cc) {
+      // if this frag isn't contiguous, clear the parser so cues with bad start/end times aren't added to the textTrack
+      if (sn !== this.lastSn + 1) {
         this.cea608Parser.reset();
       }
       this.lastSn = sn;


### PR DESCRIPTION
There's no need to clear the 608 parser when discontinuities are encountered. The start/end times are only affected by seeks that result in loading a non-contiguous fragment, resulting in the start time coming from the previous fragment and the end time from the new fragment being remuxed.

JW7-3620