### PR TITLE
Fix subtitle cue timing for dynamic ad insertion

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -180,7 +180,8 @@ class TimelineController extends EventHandler {
   onManifestLoading()
   {
     this.lastSn = -1; // Detect discontiguity in fragment parsing
-    this.lastDiscontinuity = { cc: 0, start: 0, new: false }; // Detect discontinuity in subtitle manifests
+    this.prevCC = -1;
+    this.vttCCs = {ccOffset: 0}; // Detect discontinuity in subtitle manifests
   }
 
   onManifestLoaded(data) {
@@ -214,8 +215,10 @@ class TimelineController extends EventHandler {
   }
 
   onFragLoaded(data) {
-    if (data.frag.type === 'main') {
-      var sn = data.frag.sn;
+    let frag = data.frag,
+      payload = data.payload;
+    if (frag.type === 'main') {
+      var sn = frag.sn;
       // if this frag isn't contiguous, clear the parser so cues with bad start/end times aren't added to the textTrack
       if (sn !== this.lastSn + 1) {
         this.cea608Parser.reset();
@@ -228,38 +231,38 @@ class TimelineController extends EventHandler {
       this.lastSn = sn;
     }
     // If fragment is subtitle type, parse as WebVTT.
-    else if (data.frag.type === 'subtitle') {
-      if (data.payload.byteLength) {
+    else if (frag.type === 'subtitle') {
+      if (payload.byteLength) {
         // We need an initial synchronisation PTS. Store fragments as long as none has arrived.
         if (typeof this.initPTS === 'undefined') {
           this.unparsedVttFrags.push(data);
           return;
         }
-
-        let discontinuity = this.lastDiscontinuity;
-        if (discontinuity.cc < data.frag.cc) {
-          discontinuity = { cc: data.frag.cc, start: data.frag.start, new: true };
+        let vttCCs = this.vttCCs;
+        if (!vttCCs[frag.cc]) {
+          vttCCs[frag.cc] = { start: frag.start, prevCC: this.prevCC, new: true };
+          this.prevCC = frag.cc;
         }
         let textTracks = this.textTracks,
           hls = this.hls;
 
         // Parse the WebVTT file contents.
-        WebVTTParser.parse(data.payload, this.initPTS, discontinuity, function (cues) {
+        WebVTTParser.parse(payload, this.initPTS, vttCCs, frag.cc, function (cues) {
             // Add cues and trigger event with success true.
             cues.forEach(cue => {
-              textTracks[data.frag.trackId].addCue(cue);
+              textTracks[frag.trackId].addCue(cue);
             });
-            hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, {success: true, frag: data.frag});
+            hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, {success: true, frag: frag});
           },
           function (e) {
             // Something went wrong while parsing. Trigger event with success false.
             logger.log(`Failed to parse VTT cue: ${e}`);
-            hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, {success: false, frag: data.frag});
+            hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, {success: false, frag: frag});
           });
       }
       else {
         // In case there is no payload, finish unsuccessfully.
-        this.hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, {success: false, frag: data.frag});
+        this.hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, {success: false, frag: frag});
       }
     }
   }


### PR DESCRIPTION
Fix for cue start and end times when discontinuities are added because of dynamically inserted ads.

There are 2 cases:
1. When local time is provided, the discontinuity time becomes the position from which cues are offset.
2. When there's no local time but presentation time is provided, we need to determine and add the ad playback time to the presentation time.

JW7-3674