### PR TITLE
Increase 608 parser limit to 100 columns

### DIFF
--- a/src/utils/cea-608-parser.js
+++ b/src/utils/cea-608-parser.js
@@ -151,7 +151,7 @@ var getCharForByte = function(byte) {
 };
 
 var NR_ROWS = 15,
-    NR_COLS = 32;
+    NR_COLS = 100;
 // Tables to look up row from PAC data
 var rowsLowCh1 = {0x11 : 1, 0x12 : 3, 0x15 : 5, 0x16 : 7, 0x17 : 9, 0x10 : 11, 0x13 : 12, 0x14 : 14};
 var rowsHighCh1 = {0x11 : 2, 0x12 : 4, 0x15 : 6, 0x16 : 8, 0x17 : 10, 0x13 : 13, 0x14 : 15};
@@ -510,7 +510,7 @@ class CaptionScreen {
         //Make sure this only affects Roll-up Captions by checking this.nrRollUpRows
         if (this.nrRollUpRows && this.currRow !== newRow) {
           //clear all rows first
-          for (var i = 0; i < NR_ROWS; i++) {
+          for (let i = 0; i < NR_ROWS; i++) {
             this.rows[i].clear();
           }
 
@@ -521,7 +521,7 @@ class CaptionScreen {
           //We use the cueStartTime value to check this.
           var prevLineTime = lastOutputScreen.rows[topRowIndex].cueStartTime;
           if(prevLineTime && prevLineTime < logger.time) {
-            for (i = 0; i < this.nrRollUpRows; i++) {
+            for (let i = 0; i < this.nrRollUpRows; i++) {
               this.rows[newRow-this.nrRollUpRows+i+1].copy(lastOutputScreen.rows[topRowIndex+i]);
             }
           }

--- a/src/utils/cues.js
+++ b/src/utils/cues.js
@@ -1,4 +1,6 @@
-var Cues = {
+import { fixLineBreaks } from './vttparser';
+
+const Cues = {
 
   newCue: function(track, startTime, endTime, captionScreen) {
     var row;
@@ -31,7 +33,7 @@ var Cues = {
         }
         //To be used for cleaning-up orphaned roll-up captions
         row.cueStartTime = startTime;
-        cue = new VTTCue(startTime, endTime, text.trim());
+        cue = new VTTCue(startTime, endTime, fixLineBreaks(text.trim()));
 
         if (indent >= 16)
         {

--- a/src/utils/vttparser.js
+++ b/src/utils/vttparser.js
@@ -234,6 +234,10 @@ function parseCue(input, cue, regionList) {
   consumeCueSettings(input, cue);
 }
 
+function fixLineBreaks(input) {
+  return input.replace(/<br(?: \/)?>/gi, '\n');
+}
+
 VTTParser.prototype = {
   parse: function(data) {
     var self = this;
@@ -244,10 +248,6 @@ VTTParser.prototype = {
     if (data) {
       // Try to decode the data that we received.
       self.buffer += self.decoder.decode(data, {stream: true});
-    }
-
-    function fixLineBreaks(input) {
-      return input.replace(/<br(?: \/)?>/gi, '\n');
     }
 
     function collectNextLine() {
@@ -429,5 +429,7 @@ VTTParser.prototype = {
     return this;
   }
 };
+
+export { fixLineBreaks };
 
 export default VTTParser;


### PR DESCRIPTION
The 32 column limit prevents in-band captions from being parsed completely. As a result we saw characters, lines and complete cues missing. Increasing the limit and adding the same formatting for line breaks added to VTT parser fixes the issue in our test stream (uplynk encoding).

JW7-3679