### PR TITLE
Enhance ability to detect when short fragments must be downloaded

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -158,18 +158,18 @@ class AudioStreamController extends EventHandler {
             break;
           }
 
-        // we just got done loading the final fragment, check if we need to finalize media stream
-        if (!trackDetails.live && fragPrevious && fragPrevious.sn === trackDetails.endSN) {
-            // if we are not seeking or if we are seeking but everything (almost) til the end is buffered, let's signal eos
-            // we don't compare exactly media.duration === bufferInfo.end as there could be some subtle media duration difference when switching
-            // between different renditions. using half frag duration should help cope with these cases.
-            if (!this.media.seeking || (this.media.duration-bufferEnd) < fragPrevious.duration/2) {
-            // Finalize the media stream
-            this.hls.trigger(Event.BUFFER_EOS,{ type : 'audio'});
-            this.state = State.ENDED;
-            break;
+          // we just got done loading the final fragment, check if we need to finalize media stream
+          if (!trackDetails.live && fragPrevious && fragPrevious.sn === trackDetails.endSN) {
+              // if we are not seeking or if we are seeking but everything (almost) til the end is buffered, let's signal eos
+              // we don't compare exactly media.duration === bufferInfo.end as there could be some subtle media duration difference when switching
+              // between different renditions. using half frag duration should help cope with these cases.
+              if (!this.media.seeking || (this.media.duration-bufferEnd) < fragPrevious.duration/2) {
+              // Finalize the media stream
+              this.hls.trigger(Event.BUFFER_EOS,{ type : 'audio'});
+              this.state = State.ENDED;
+              break;
+            }
           }
-        }
 
           // find fragment index, contiguous with end of buffer position
           let fragments = trackDetails.fragments,
@@ -182,34 +182,39 @@ class AudioStreamController extends EventHandler {
           if (bufferEnd < start) {
             frag = fragments[0];
           } else {
-            let foundFrag;
-            let maxFragLookUpTolerance = config.maxFragLookUpTolerance;
+            let foundFrag,
+                // Search tolerance should be large enough to include the smallest fragment in the stream.
+                shortestFragDuration = fragments.reduce((minVal, frag) => { return Math.min(minVal, frag.duration); }, fragments[0].duration),
+                maxFragLookUpTolerance = Math.min(config.maxFragLookUpTolerance, shortestFragDuration),
+                fragNext = (fragPrevious) ? fragments.find((fragment) => { return fragment.sn === fragPrevious.sn + 1; }) : undefined,
+                fragmentWithinToleranceTest = (candidate) => {
+                  // offset should be within fragment boundary - config.maxFragLookUpTolerance
+                  // this is to cope with situations like
+                  // bufferEnd = 9.991
+                  // frag[Ø] : [0,10]
+                  // frag[1] : [10,20]
+                  // bufferEnd is within frag[0] range ... although what we are expecting is to return frag[1] here
+                  //              frag start               frag start+duration
+                  //                  |-----------------------------|
+                  //              <--->                         <--->
+                  //  ...--------><-----------------------------><---------....
+                  // previous frag         matching fragment         next frag
+                  //  return -1             return 0                 return 1
+                  //logger.log(`level/sn/start/end/bufEnd:${level}/${candidate.sn}/${candidate.start}/${(candidate.start+candidate.duration)}/${bufferEnd}`);
+                  if ((candidate.start + candidate.duration - maxFragLookUpTolerance) <= bufferEnd) {
+                    return 1;
+                  }// if maxFragLookUpTolerance will have negative value then don't return -1 for first element
+                  else if (candidate.start - maxFragLookUpTolerance > bufferEnd && candidate.start) {
+                    return -1;
+                  }
+                  return 0;
+                };
+
             if (bufferEnd < end) {
               if (bufferEnd > end - maxFragLookUpTolerance) {
                 maxFragLookUpTolerance = 0;
               }
-              foundFrag = BinarySearch.search(fragments, (candidate) => {
-                // offset should be within fragment boundary - config.maxFragLookUpTolerance
-                // this is to cope with situations like
-                // bufferEnd = 9.991
-                // frag[Ø] : [0,10]
-                // frag[1] : [10,20]
-                // bufferEnd is within frag[0] range ... although what we are expecting is to return frag[1] here
-                    //              frag start               frag start+duration
-                    //                  |-----------------------------|
-                    //              <--->                         <--->
-                    //  ...--------><-----------------------------><---------....
-                    // previous frag         matching fragment         next frag
-                    //  return -1             return 0                 return 1
-                //logger.log(`level/sn/start/end/bufEnd:${level}/${candidate.sn}/${candidate.start}/${(candidate.start+candidate.duration)}/${bufferEnd}`);
-                if ((candidate.start + candidate.duration - maxFragLookUpTolerance) <= bufferEnd) {
-                  return 1;
-                }
-                else if (candidate.start - maxFragLookUpTolerance > bufferEnd) {
-                  return -1;
-                }
-                return 0;
-              });
+              foundFrag = (fragNext && fragmentWithinToleranceTest(fragNext) === 0) ? fragNext : BinarySearch.search(fragments, fragmentWithinToleranceTest);
             } else {
               // reach end of playlist
               foundFrag = fragments[fragLen-1];

--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -183,9 +183,7 @@ class AudioStreamController extends EventHandler {
             frag = fragments[0];
           } else {
             let foundFrag,
-                // Search tolerance should be large enough to include the smallest fragment in the stream.
-                shortestFragDuration = fragments.reduce((minVal, frag) => { return Math.min(minVal, frag.duration); }, fragments[0].duration),
-                maxFragLookUpTolerance = Math.min(config.maxFragLookUpTolerance, shortestFragDuration),
+                maxFragLookUpTolerance = config.maxFragLookUpTolerance,
                 fragNext = (fragPrevious) ? fragments.find((fragment) => { return fragment.sn === fragPrevious.sn + 1; }) : undefined,
                 fragmentWithinToleranceTest = (candidate) => {
                   // offset should be within fragment boundary - config.maxFragLookUpTolerance
@@ -201,10 +199,11 @@ class AudioStreamController extends EventHandler {
                   // previous frag         matching fragment         next frag
                   //  return -1             return 0                 return 1
                   //logger.log(`level/sn/start/end/bufEnd:${level}/${candidate.sn}/${candidate.start}/${(candidate.start+candidate.duration)}/${bufferEnd}`);
-                  if ((candidate.start + candidate.duration - maxFragLookUpTolerance) <= bufferEnd) {
+                  let candidateLookupTolerance = Math.min(maxFragLookUpTolerance, candidate.duration);
+                  if ((candidate.start + candidate.duration - candidateLookupTolerance) <= bufferEnd) {
                     return 1;
                   }// if maxFragLookUpTolerance will have negative value then don't return -1 for first element
-                  else if (candidate.start - maxFragLookUpTolerance > bufferEnd && candidate.start) {
+                  else if (candidate.start - candidateLookupTolerance > bufferEnd && candidate.start) {
                     return -1;
                   }
                   return 0;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -366,34 +366,38 @@ class StreamController extends EventHandler {
 
     let frag,
         foundFrag,
-        maxFragLookUpTolerance = config.maxFragLookUpTolerance;
+        // Search tolerance should be large enough to include the smallest fragment in the stream.
+        shortestFragDuration = fragments.reduce((minVal, frag) => { return Math.min(minVal, frag.duration); }, fragments[0].duration),
+        maxFragLookUpTolerance = Math.min(config.maxFragLookUpTolerance, shortestFragDuration),
+        fragNext = (fragPrevious) ? fragments.find((fragment) => { return fragment.sn === fragPrevious.sn + 1; }) : undefined,
+        fragmentWithinToleranceTest = (candidate) => {
+          // offset should be within fragment boundary - config.maxFragLookUpTolerance
+          // this is to cope with situations like
+          // bufferEnd = 9.991
+          // frag[Ø] : [0,10]
+          // frag[1] : [10,20]
+          // bufferEnd is within frag[0] range ... although what we are expecting is to return frag[1] here
+          //              frag start               frag start+duration
+          //                  |-----------------------------|
+          //              <--->                         <--->
+          //  ...--------><-----------------------------><---------....
+          // previous frag         matching fragment         next frag
+          //  return -1             return 0                 return 1
+          //logger.log(`level/sn/start/end/bufEnd:${level}/${candidate.sn}/${candidate.start}/${(candidate.start+candidate.duration)}/${bufferEnd}`);
+          if ((candidate.start + candidate.duration - maxFragLookUpTolerance) <= bufferEnd) {
+            return 1;
+          }// if maxFragLookUpTolerance will have negative value then don't return -1 for first element
+          else if (candidate.start - maxFragLookUpTolerance > bufferEnd && candidate.start) {
+            return -1;
+          }
+          return 0;
+        };
 
     if (bufferEnd < end) {
       if (bufferEnd > end - maxFragLookUpTolerance) {
         maxFragLookUpTolerance = 0;
       }
-      foundFrag = BinarySearch.search(fragments, (candidate) => {
-        // offset should be within fragment boundary - config.maxFragLookUpTolerance
-        // this is to cope with situations like
-        // bufferEnd = 9.991
-        // frag[Ø] : [0,10]
-        // frag[1] : [10,20]
-        // bufferEnd is within frag[0] range ... although what we are expecting is to return frag[1] here
-            //              frag start               frag start+duration
-            //                  |-----------------------------|
-            //              <--->                         <--->
-            //  ...--------><-----------------------------><---------....
-            // previous frag         matching fragment         next frag
-            //  return -1             return 0                 return 1
-        //logger.log(`level/sn/start/end/bufEnd:${level}/${candidate.sn}/${candidate.start}/${(candidate.start+candidate.duration)}/${bufferEnd}`);
-        if ((candidate.start + candidate.duration - maxFragLookUpTolerance) <= bufferEnd) {
-          return 1;
-        }// if maxFragLookUpTolerance will have negative value then don't return -1 for first element
-        else if (candidate.start - maxFragLookUpTolerance > bufferEnd && candidate.start) {
-          return -1;
-        }
-        return 0;
-      });
+      foundFrag = (fragNext && fragmentWithinToleranceTest(fragNext) === 0) ? fragNext : BinarySearch.search(fragments, fragmentWithinToleranceTest);
     } else {
       // reach end of playlist
       foundFrag = fragments[fragLen-1];

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -366,9 +366,7 @@ class StreamController extends EventHandler {
 
     let frag,
         foundFrag,
-        // Search tolerance should be large enough to include the smallest fragment in the stream.
-        shortestFragDuration = fragments.reduce((minVal, frag) => { return Math.min(minVal, frag.duration); }, fragments[0].duration),
-        maxFragLookUpTolerance = Math.min(config.maxFragLookUpTolerance, shortestFragDuration),
+        maxFragLookUpTolerance = config.maxFragLookUpTolerance,
         fragNext = (fragPrevious) ? fragments.find((fragment) => { return fragment.sn === fragPrevious.sn + 1; }) : undefined,
         fragmentWithinToleranceTest = (candidate) => {
           // offset should be within fragment boundary - config.maxFragLookUpTolerance
@@ -384,10 +382,12 @@ class StreamController extends EventHandler {
           // previous frag         matching fragment         next frag
           //  return -1             return 0                 return 1
           //logger.log(`level/sn/start/end/bufEnd:${level}/${candidate.sn}/${candidate.start}/${(candidate.start+candidate.duration)}/${bufferEnd}`);
-          if ((candidate.start + candidate.duration - maxFragLookUpTolerance) <= bufferEnd) {
+          // Set the lookup tolerance to be small enough to detect the current segment.
+          let candidateLookupTolerance = Math.min(maxFragLookUpTolerance, candidate.duration);
+          if (candidate.start + candidate.duration - candidateLookupTolerance <= bufferEnd) {
             return 1;
-          }// if maxFragLookUpTolerance will have negative value then don't return -1 for first element
-          else if (candidate.start - maxFragLookUpTolerance > bufferEnd && candidate.start) {
+          } // if maxFragLookUpTolerance will have negative value then don't return -1 for first element
+          else if (candidate.start - candidateLookupTolerance > bufferEnd && candidate.start) {
             return -1;
           }
           return 0;


### PR DESCRIPTION
These changes enhance the ability of the stream controllers to know when short segments need to be downloaded by ensuring that the maxFragLookUpTolerance is at least as large as the smallest segment.  If the value is larger than the smallest segment, then the binary search can pass over segments necessary to playback.
This also makes it easier to try find the correct fragment to download more quickly by checking the item with the next sn value to see if it should be used before searching all fragments that are available first.

JW7-3621