### PR TITLE
Handle empty manifests without crashing

### DIFF
--- a/src/controller/cap-level-controller.js
+++ b/src/controller/cap-level-controller.js
@@ -10,9 +10,9 @@ class CapLevelController extends EventHandler {
     super(hls,
       Event.FPS_DROP_LEVEL_CAPPING,
       Event.MEDIA_ATTACHING,
-      Event.MANIFEST_PARSED);   
+      Event.MANIFEST_PARSED);
 	}
-	
+
 	destroy() {
     if (this.hls.config.capLevelToPlayerSize) {
       this.media = this.restrictedLevels = null;
@@ -22,7 +22,7 @@ class CapLevelController extends EventHandler {
       }
     }
   }
-	
+
   onFpsDropLevelCapping(data) {
     if (!this.restrictedLevels) {
       this.restrictedLevels = [];
@@ -31,9 +31,9 @@ class CapLevelController extends EventHandler {
       this.restrictedLevels.push(data.droppedLevel);
     }
   }
-  
+
 	onMediaAttaching(data) {
-    this.media = data.media instanceof HTMLVideoElement ? data.media : null;  
+    this.media = data.media instanceof HTMLVideoElement ? data.media : null;
   }
 
   onManifestParsed(data) {
@@ -46,7 +46,7 @@ class CapLevelController extends EventHandler {
       this.detectPlayerSize();
     }
   }
-  
+
   detectPlayerSize() {
     if (this.media) {
       let levelsLength = this.levels ? this.levels.length : 0;
@@ -57,11 +57,11 @@ class CapLevelController extends EventHandler {
           // usually happen when the user go to the fullscreen mode.
           this.hls.streamController.nextLevelSwitch();
         }
-        this.autoLevelCapping = this.hls.autoLevelCapping;        
-      }  
+        this.autoLevelCapping = this.hls.autoLevelCapping;
+      }
     }
   }
-  
+
   /*
   * returns level should be the one with the dimensions equal or greater than the media (player) dimensions (so the video will be downscaled)
   */
@@ -73,7 +73,7 @@ class CapLevelController extends EventHandler {
         mHeight = this.mediaHeight,
         lWidth = 0,
         lHeight = 0;
-        
+
     for (i = 0; i <= capLevelIndex; i++) {
       level = this.levels[i];
       if (this.isLevelRestricted(i)) {
@@ -85,14 +85,14 @@ class CapLevelController extends EventHandler {
       if (mWidth <= lWidth || mHeight <= lHeight) {
         break;
       }
-    }  
+    }
     return result;
   }
-  
+
   isLevelRestricted(level) {
     return (this.restrictedLevels && this.restrictedLevels.indexOf(level) !== -1) ? true : false;
   }
-  
+
   get contentScaleFactor() {
     let pixelRatio = 1;
     try {
@@ -100,7 +100,7 @@ class CapLevelController extends EventHandler {
     } catch(e) {}
     return pixelRatio;
   }
-  
+
   get mediaWidth() {
     let width;
     if (this.media) {
@@ -109,12 +109,12 @@ class CapLevelController extends EventHandler {
     }
     return width;
   }
-  
+
   get mediaHeight() {
     let height;
     if (this.media) {
       height = this.media.height || this.media.clientHeight || this.media.offsetHeight;
-      height *= this.contentScaleFactor; 
+      height *= this.contentScaleFactor;
     }
     return height;
   }

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -222,6 +222,10 @@ class LevelController extends EventHandler {
         levelId = data.context.level;
         levelError = true;
         break;
+      case ErrorDetails.MANIFEST_EMPTY_ERROR:
+        levelId = data.context.level;
+        levelError = true;
+        break;
       default:
         break;
     }

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -240,11 +240,12 @@ class LevelController extends EventHandler {
       if (level.urlId < (level.url.length - 1)) {
         level.urlId++;
         level.details = undefined;
-        removeLevel = false;
         logger.warn(`level controller,${details} for level ${levelId}: switching to redundant stream id ${level.urlId}`);
       } else {
         if (removeLevel) {
+          logger.warn(`Bad level encountered, removing & forcing to auto mode`);
           this._levels = this.levels.filter((l, index) => index !== levelId);
+          hls.currentLevel = -1;
           hls.trigger(Event.LEVEL_REMOVED, { level: levelId });
         }
         // we could try to recover if in auto mode and current level not lowest level (0)
@@ -252,11 +253,7 @@ class LevelController extends EventHandler {
         if (recoverable) {
           logger.warn(`level controller,${details}: emergency switch-down for next fragment`);
           abrController.nextAutoLevel = minAutoLevel;
-        } else if (removeLevel) {
-          // Recover by forcing to auto after removing the bad level
-          logger.warn(`Bad level encountered, forcing to auto mode`);
-          hls.currentLevel = -1;
-        } else if(level && level.details && level.details.live) {
+        }  else if(level && level.details && level.details.live) {
           logger.warn(`level controller,${details} on live stream, discard`);
           if (levelError) {
             // reset this._level so that another call to set level() will retrigger a frag load

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -280,7 +280,6 @@ class LevelController extends EventHandler {
           }
         }
         if (removeLevel) {
-          console.warn('removeLevel')
           hls.trigger(Event.LEVEL_REMOVED, { level: levelId });
         }
       }

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -45,7 +45,9 @@ class StreamController extends EventHandler {
       Event.AUDIO_TRACK_SWITCH,
       Event.BUFFER_CREATED,
       Event.BUFFER_APPENDED,
-      Event.BUFFER_FLUSHED);
+      Event.BUFFER_FLUSHED,
+      Event.LEVEL_REMOVED
+    );
 
     this.config = hls.config;
     this.audioCodecSwap = false;
@@ -1422,6 +1424,10 @@ _checkBuffer() {
     this.state = State.IDLE;
     // reset reference to frag
     this.fragPrevious = null;
+  }
+
+  onLevelRemoved(data) {
+    this.levels = this.levels.filter((level, index) => index !== data.level);
   }
 
   swapAudioCodec() {

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1428,6 +1428,8 @@ _checkBuffer() {
 
   onLevelRemoved(data) {
     this.levels = this.levels.filter((level, index) => index !== data.level);
+    this.state = State.BUFFER_FLUSHING;
+    this.hls.trigger(Event.BUFFER_FLUSHING, {startOffset: 0, endOffset: Number.POSITIVE_INFINITY});
   }
 
   swapAudioCodec() {

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1428,8 +1428,6 @@ _checkBuffer() {
 
   onLevelRemoved(data) {
     this.levels = this.levels.filter((level, index) => index !== data.level);
-    this.state = State.BUFFER_FLUSHING;
-    this.hls.trigger(Event.BUFFER_FLUSHING, {startOffset: 0, endOffset: Number.POSITIVE_INFINITY});
   }
 
   swapAudioCodec() {

--- a/src/errors.js
+++ b/src/errors.js
@@ -16,6 +16,8 @@ export const ErrorDetails = {
   MANIFEST_PARSING_ERROR: 'manifestParsingError',
   // Identifier for a manifest with only incompatible codecs error - data: { url : faulty URL, reason : error reason}
   MANIFEST_INCOMPATIBLE_CODECS_ERROR: 'manifestIncompatibleCodecsError',
+  //
+  MANIFEST_EMPTY_ERROR: 'manifestEmptyError',
   // Identifier for a level load error - data: { url : faulty URL, response : { code: error code, text: error text }}
   LEVEL_LOAD_ERROR: 'levelLoadError',
   // Identifier for a level load timeout - data: { url : faulty URL, response : { code: error code, text: error text }}

--- a/src/events.js
+++ b/src/events.js
@@ -40,6 +40,8 @@ module.exports = {
   // fired when a level switch is requested - data: { level : id of new level }
   LEVEL_SWITCH: 'hlsLevelSwitch',
   // fired to notify that audio track lists has been updated data: { audioTracks : audioTracks}
+  LEVEL_REMOVED: 'hlsLevelRemoved',
+  // fired when a level should no longer be used
   AUDIO_TRACKS_UPDATED: 'hlsAudioTracksUpdated',
   // fired when an audio track switch occurs - data: {  id : audio track id}
   AUDIO_TRACK_SWITCH: 'hlsAudioTrackSwitch',

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -407,7 +407,7 @@ class PlaylistLoader extends EventHandler {
           }
           hls.trigger(Event.MANIFEST_LOADED, {levels, audioTracks, subtitles, url, stats});
         } else {
-          hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_PARSING_ERROR, fatal: true, url: url, reason: 'no level found in manifest'});
+          hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_EMPTY_ERROR, fatal: false, url: url, reason: 'no level found in manifest', context });
         }
       }
     } else {


### PR DESCRIPTION
- New event: `LEVEL_REMOVED`
- Trigger `LEVEL_REMOVED` on receiving empty manifest
- Remove empty level & emergency downstwitch to auto