### PR TITLE
Undefined pos audio stream

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -166,8 +166,10 @@ class AudioStreamController extends EventHandler {
         // if we have not yet loaded any fragment, start loading from start position
         if (this.loadedmetadata) {
           pos = this.media.currentTime;
-        } else {
+        } else if (this.nextLoadPosition){
           pos = this.nextLoadPosition;
+        } else {
+          pos = 0;
         }
         let media = this.mediaBuffer ? this.mediaBuffer : this.media,
             bufferInfo = BufferHelper.bufferInfo(media,pos,config.maxBufferHole),

--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -166,7 +166,7 @@ class AudioStreamController extends EventHandler {
         // if we have not yet loaded any fragment, start loading from start position
         if (this.loadedmetadata) {
           pos = this.media.currentTime;
-        } else if (this.nextLoadPosition){
+        } else if (this.nextLoadPosition) {
           pos = this.nextLoadPosition;
         } else {
           pos = 0;


### PR DESCRIPTION
- When preloading, we don't know the nextLoadPosition. Default to 0 so the `undefined` pos doesn't cause exceptions later on