### PR TITLE
Align PTS using CC when CC changes during level switch

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -347,9 +347,13 @@ class StreamController extends EventHandler {
          compute playlist sliding and find the right one after in case it was not the right consecutive one */
       if (fragPrevious) {
         var targetSN = fragPrevious.sn + 1;
+        var targetCC = fragPrevious.cc + 1;
         if (targetSN >= levelDetails.startSN && targetSN <= levelDetails.endSN) {
           frag = fragments[targetSN - levelDetails.startSN];
           logger.log(`live playlist, switching playlist, load frag with next SN: ${frag.sn}`);
+        } else if (targetCC >= levelDetails.startCC && targetCC <= levelDetails.endCC) {
+          frag = fragments.find(f => f.cc === targetCC);
+          console.info(`Loading frag with next CC: ${ frag.cc }`);
         }
       }
       if (!frag) {
@@ -848,8 +852,15 @@ class StreamController extends EventHandler {
         duration = newDetails.totalduration,
         sliding = 0;
 
-    logger.log(`level ${newLevelId} loaded [${newDetails.startSN},${newDetails.endSN}],duration:${duration}`);
-    this.levelLastLoaded = newLevelId;
+    console.info(`level ${newLevelId} loaded [${newDetails.startSN},${newDetails.endSN}], cc [${newDetails.startCC}, ${newDetails.endCC}] duration:${duration}`);
+
+    let lastFrag;
+    if (this.fragPrevious) {
+      lastFrag = this.fragPrevious;
+    } else if (this.levelLastLoaded) {
+      const lastLevel = this.levels[this.levelLastLoaded].details;
+      lastFrag = lastLevel.fragments[lastLevel.fragments.length - 1];
+    }
 
     if (newDetails.live) {
       var curDetails = curLevel.details;
@@ -862,15 +873,30 @@ class StreamController extends EventHandler {
           logger.log(`live playlist sliding:${sliding.toFixed(3)}`);
         } else {
           logger.log('live playlist - outdated PTS, unknown sliding');
+          if (lastFrag) {
+            const { cc: prevCC } = lastFrag;
+            if (this.startFragRequested && (newDetails.endCC > newDetails.startCC || newDetails.startCC > prevCC)) {
+              console.info('Adjusting PTS by reference due to CC increase within level');
+              LevelHelper.alignPTSByCC(this.levels[this.levelLastLoaded].details, newDetails);
+            }
+          }
         }
       } else {
-        newDetails.PTSKnown = false;
         logger.log('live playlist - first load, unknown sliding');
+        newDetails.PTSKnown = false;
+        if (lastFrag) {
+          const { cc: prevCC } = lastFrag;
+          if (this.startFragRequested && (newDetails.endCC > newDetails.startCC || newDetails.startCC > prevCC)) {
+            console.info('Adjusting PTS by reference due to CC increase within level');
+            LevelHelper.alignPTSByCC(this.levels[this.levelLastLoaded].details, newDetails);
+          }
+        }
       }
     } else {
       newDetails.PTSKnown = false;
     }
     // override level info
+    this.levelLastLoaded = newLevelId;
     curLevel.details = newDetails;
     this.hls.trigger(Event.LEVEL_UPDATED, { details: newDetails, level: newLevelId });
 
@@ -1457,7 +1483,7 @@ _checkBuffer() {
     // move to IDLE once flush complete. this should trigger new fragment loading
     this.state = State.IDLE;
     // reset reference to frag
-    this.fragPrevious = null;
+    // this.fragPrevious = null;
   }
 
   onLevelRemoved(data) {

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -353,7 +353,7 @@ class StreamController extends EventHandler {
           logger.log(`live playlist, switching playlist, load frag with next SN: ${frag.sn}`);
         } else if (targetCC >= levelDetails.startCC && targetCC <= levelDetails.endCC) {
           frag = fragments.find(f => f.cc === targetCC);
-          console.info(`Loading frag with next CC: ${ frag.cc }`);
+          logger.log(`Live playlist switch, cannot find frag with target SN. Loading frag with next CC: ${ frag.cc }`);
         }
       }
       if (!frag) {
@@ -846,24 +846,17 @@ class StreamController extends EventHandler {
   }
 
   onLevelLoaded(data) {
-    var newDetails = data.details,
-        newLevelId = data.level,
-        curLevel = this.levels[newLevelId],
-        duration = newDetails.totalduration,
-        sliding = 0;
+    const newDetails = data.details;
+    const newLevelId = data.level;
+    const lastLevel = this.levels[this.levelLastLoaded];
+    const curLevel = this.levels[newLevelId];
+    const duration = newDetails.totalduration;
+    let sliding = 0;
 
-    console.info(`level ${newLevelId} loaded [${newDetails.startSN},${newDetails.endSN}], cc [${newDetails.startCC}, ${newDetails.endCC}] duration:${duration}`);
-
-    let lastFrag;
-    if (this.fragPrevious) {
-      lastFrag = this.fragPrevious;
-    } else if (this.levelLastLoaded) {
-      const lastLevel = this.levels[this.levelLastLoaded].details;
-      lastFrag = lastLevel.fragments[lastLevel.fragments.length - 1];
-    }
+    logger.log(`level ${newLevelId} loaded [${newDetails.startSN},${newDetails.endSN}], cc [${newDetails.startCC}, ${newDetails.endCC}] duration:${duration}`);
 
     if (newDetails.live) {
-      var curDetails = curLevel.details;
+      const curDetails = curLevel.details;
       if (curDetails && newDetails.fragments.length > 0) {
         // we already have details for that level, merge them
         LevelHelper.mergeDetails(curDetails,newDetails);
@@ -873,24 +866,12 @@ class StreamController extends EventHandler {
           logger.log(`live playlist sliding:${sliding.toFixed(3)}`);
         } else {
           logger.log('live playlist - outdated PTS, unknown sliding');
-          if (lastFrag) {
-            const { cc: prevCC } = lastFrag;
-            if (this.startFragRequested && (newDetails.endCC > newDetails.startCC || newDetails.startCC > prevCC)) {
-              console.info('Adjusting PTS by reference due to CC increase within level');
-              LevelHelper.alignPTSByCC(this.levels[this.levelLastLoaded].details, newDetails);
-            }
-          }
+          LevelHelper.alignDiscontinuities(this.fragPrevious, lastLevel, newDetails);
         }
       } else {
         logger.log('live playlist - first load, unknown sliding');
         newDetails.PTSKnown = false;
-        if (lastFrag) {
-          const { cc: prevCC } = lastFrag;
-          if (this.startFragRequested && (newDetails.endCC > newDetails.startCC || newDetails.startCC > prevCC)) {
-            console.info('Adjusting PTS by reference due to CC increase within level');
-            LevelHelper.alignPTSByCC(this.levels[this.levelLastLoaded].details, newDetails);
-          }
-        }
+        LevelHelper.alignDiscontinuities(this.fragPrevious, lastLevel, newDetails);
       }
     } else {
       newDetails.PTSKnown = false;
@@ -1483,7 +1464,7 @@ _checkBuffer() {
     // move to IDLE once flush complete. this should trigger new fragment loading
     this.state = State.IDLE;
     // reset reference to frag
-    // this.fragPrevious = null;
+    this.fragPrevious = null;
   }
 
   onLevelRemoved(data) {

--- a/src/helper/level-helper.js
+++ b/src/helper/level-helper.js
@@ -142,7 +142,9 @@ class LevelHelper {
     if (LevelHelper.shouldAlignOnDiscontinuities(lastFrag, lastLevel, details)) {
         logger.log('Adjusting PTS using last level due to CC increase within current level');
         const referenceFrag = LevelHelper.findDiscontinuousReferenceFrag(lastLevel.details, details);
-        LevelHelper.adjustPtsByReferenceFrag(referenceFrag, details);
+        if (referenceFrag) {
+          LevelHelper.adjustPtsByReferenceFrag(referenceFrag, details);
+        }
     }
   }
 

--- a/src/helper/level-helper.js
+++ b/src/helper/level-helper.js
@@ -7,8 +7,8 @@ import {logger} from '../utils/logger';
 class LevelHelper {
 
   static mergeDetails(oldDetails,newDetails) {
-    var start = Math.max(oldDetails.startSN,newDetails.startSN)-newDetails.startSN,
-        end = Math.min(oldDetails.endSN,newDetails.endSN)-newDetails.startSN,
+    var startSn = Math.max(oldDetails.startSN,newDetails.startSN)-newDetails.startSN,
+        endSn = Math.min(oldDetails.endSN,newDetails.endSN)-newDetails.startSN,
         delta = newDetails.startSN - oldDetails.startSN,
         oldfragments = oldDetails.fragments,
         newfragments = newDetails.fragments,
@@ -16,12 +16,12 @@ class LevelHelper {
         PTSFrag;
 
     // check if old/new playlists have fragments in common
-    if ( end < start) {
+    if (endSn < startSn) {
       newDetails.PTSKnown = false;
       return;
     }
     // loop through overlapping SN and update startPTS , cc, and duration if any found
-    for(var i = start ; i <= end ; i++) {
+    for(var i = startSn ; i <= endSn ; i++) {
       var oldFrag = oldfragments[delta+i],
           newFrag = newfragments[i];
       if (newFrag && oldFrag) {
@@ -133,6 +133,40 @@ class LevelHelper {
         fragTo.start = fragFrom.start - fragTo.duration;
       }
     }
+  }
+
+  static adjustPtsByReference(referenceFrag, details) {
+    if (!details.fragments || !referenceFrag) {
+      return;
+    }
+    details.fragments.forEach(frag => {
+      if (frag) {
+        console.info(`oldStart ${frag.start}`);
+        frag.duration = referenceFrag.duration;
+        frag.start = frag.startPTS = referenceFrag.startPTS + frag.start;
+        console.info(`newStart ${frag.start}`);
+        frag.endPTS = referenceFrag.endPTS + frag.duration;
+      }
+    });
+    details.PTSKnown = true;
+  }
+
+  static alignPTSByCC(prevDetails, curDetails) {
+    const prevFrags = prevDetails.fragments;
+    const curFrags = curDetails.fragments;
+
+    // Find the first frag in the previous level which matches the starting CC
+    const startCC = curFrags[0].cc;
+    const prevStartFrag = prevFrags.find(frag => {
+      return frag.cc === startCC;
+    });
+
+    if (!prevStartFrag || (prevStartFrag && !prevStartFrag.startPTS)) {
+      console.info('No frag in previous level to align on');
+      return;
+    }
+
+    LevelHelper.adjustPtsByReference(prevStartFrag, curDetails);
   }
 }
 

--- a/src/helper/level-helper.js
+++ b/src/helper/level-helper.js
@@ -142,9 +142,7 @@ class LevelHelper {
     if (LevelHelper.shouldAlignOnDiscontinuities(lastFrag, lastLevel, details)) {
         logger.log('Adjusting PTS using last level due to CC increase within current level');
         const referenceFrag = LevelHelper.findDiscontinuousReferenceFrag(lastLevel.details, details);
-        if (referenceFrag) {
-          LevelHelper.adjustPtsByReferenceFrag(referenceFrag, details);
-        }
+        LevelHelper.adjustPtsByReferenceFrag(referenceFrag, details);
     }
   }
 
@@ -181,6 +179,10 @@ class LevelHelper {
   }
 
   static adjustPtsByReferenceFrag(referenceFrag, details) {
+    if (!referenceFrag) {
+      return;
+    }
+
     details.fragments.forEach((frag, index) => {
       if (frag) {
         frag.duration = referenceFrag.duration;

--- a/src/helper/level-helper.js
+++ b/src/helper/level-helper.js
@@ -135,38 +135,49 @@ class LevelHelper {
     }
   }
 
-  static adjustPtsByReference(referenceFrag, details) {
-    if (!details.fragments || !referenceFrag) {
-      return;
-    }
-    details.fragments.forEach(frag => {
-      if (frag) {
-        console.info(`oldStart ${frag.start}`);
-        frag.duration = referenceFrag.duration;
-        frag.start = frag.startPTS = referenceFrag.startPTS + frag.start;
-        console.info(`newStart ${frag.start}`);
-        frag.endPTS = referenceFrag.endPTS + frag.duration;
+  // If a change in CC is detected, the PTS can no longer be relied upon
+  // Attempt to align the level by using the last level - find the last frag matching the current CC and use it's PTS
+  // as a reference
+  static alignDiscontinuities(lastFrag, lastLevel, details) {
+    if (lastLevel && lastLevel.details && details) {
+      if (details.endCC > details.startCC || (lastFrag && lastFrag.cc < details.startCC)) {
+        logger.log('Adjusting PTS using last level due to CC increase within current level');
+        LevelHelper.alignPTSByCC(lastLevel.details, details);
       }
-    });
-    details.PTSKnown = true;
+    }
   }
 
   static alignPTSByCC(prevDetails, curDetails) {
     const prevFrags = prevDetails.fragments;
     const curFrags = curDetails.fragments;
 
-    // Find the first frag in the previous level which matches the starting CC
-    const startCC = curFrags[0].cc;
-    const prevStartFrag = prevFrags.find(frag => {
-      return frag.cc === startCC;
-    });
-
-    if (!prevStartFrag || (prevStartFrag && !prevStartFrag.startPTS)) {
-      console.info('No frag in previous level to align on');
+    if (!curFrags.length || !prevFrags.length) {
+      logger.log('No fragments to align');
       return;
     }
 
-    LevelHelper.adjustPtsByReference(prevStartFrag, curDetails);
+    // Find the first frag in the previous level which matches the starting CC
+    const prevStartFrag = prevFrags.find(frag => {
+      return frag.cc === curFrags[0].cc;
+    });
+
+    if (!prevStartFrag || (prevStartFrag && !prevStartFrag.startPTS)) {
+      logger.log('No frag in previous level to align on');
+      return;
+    }
+
+    LevelHelper.adjustPtsByReferenceFrag(prevStartFrag, curDetails);
+  }
+
+  static adjustPtsByReferenceFrag(referenceFrag, details) {
+    details.fragments.forEach((frag, index) => {
+      if (frag) {
+        frag.duration = referenceFrag.duration;
+        frag.end = frag.endPTS = referenceFrag.endPTS + (frag.duration * index);
+        frag.start = frag.startPTS = referenceFrag.startPTS + frag.start;
+      }
+    });
+    details.PTSKnown = true;
   }
 }
 

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -412,6 +412,8 @@ class PlaylistLoader extends EventHandler {
     level.totalduration = totalduration;
     level.averagetargetduration = totalduration / level.fragments.length;
     level.endSN = currentSN - 1;
+    level.startCC = level.fragments[0] ? level.fragments[0].cc : 0;
+    level.endCC = cc;
     return level;
   }
 

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -37,7 +37,6 @@ class MP4Remuxer {
   }
 
   remux(level,sn,cc,audioTrack,videoTrack,id3Track,textTrack,timeOffset, contiguous,accurateTimeOffset,defaultInitPTS) {
-    logger.log(`cc: ${cc} sn: ${sn} timeOffset: ${timeOffset} initPTS: ${this._initPTS}`);
     this.level = level;
     this.sn = sn;
     // generate Init Segment if needed

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -37,6 +37,7 @@ class MP4Remuxer {
   }
 
   remux(level,sn,cc,audioTrack,videoTrack,id3Track,textTrack,timeOffset, contiguous,accurateTimeOffset,defaultInitPTS) {
+    console.info(`cc: ${cc} sn: ${sn} timeOffset: ${timeOffset} initPTS: ${this._initPTS}`);
     this.level = level;
     this.sn = sn;
     // generate Init Segment if needed
@@ -60,13 +61,13 @@ class MP4Remuxer {
           if (audioData) {
             audioTrackLength = audioData.endPTS - audioData.startPTS;
           }
-          this.remuxVideo(videoTrack,timeOffset,contiguous,audioTrackLength);
+          this.remuxVideo(videoTrack,timeOffset,contiguous,audioTrackLength, cc);
         }
       } else {
         let videoData;
         //logger.log('nb AVC samples:' + videoTrack.samples.length);
         if (videoTrack.samples.length) {
-          videoData = this.remuxVideo(videoTrack,timeOffset,contiguous);
+          videoData = this.remuxVideo(videoTrack,timeOffset,contiguous, cc);
         }
         if (videoData && audioTrack.codec) {
           this.remuxEmptyAudio(audioTrack, timeOffset, contiguous, videoData);
@@ -169,7 +170,7 @@ class MP4Remuxer {
     }
   }
 
-  remuxVideo(track, timeOffset, contiguous, audioTrackLength) {
+  remuxVideo(track, timeOffset, contiguous, audioTrackLength, cc) {
     var offset = 8,
         pesTimeScale = this.PES_TIMESCALE,
         pes2mp4ScaleFactor = this.PES2MP4SCALEFACTOR,

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -37,7 +37,7 @@ class MP4Remuxer {
   }
 
   remux(level,sn,cc,audioTrack,videoTrack,id3Track,textTrack,timeOffset, contiguous,accurateTimeOffset,defaultInitPTS) {
-    console.info(`cc: ${cc} sn: ${sn} timeOffset: ${timeOffset} initPTS: ${this._initPTS}`);
+    logger.log(`cc: ${cc} sn: ${sn} timeOffset: ${timeOffset} initPTS: ${this._initPTS}`);
     this.level = level;
     this.sn = sn;
     // generate Init Segment if needed
@@ -61,13 +61,13 @@ class MP4Remuxer {
           if (audioData) {
             audioTrackLength = audioData.endPTS - audioData.startPTS;
           }
-          this.remuxVideo(videoTrack,timeOffset,contiguous,audioTrackLength, cc);
+          this.remuxVideo(videoTrack,timeOffset,contiguous,audioTrackLength);
         }
       } else {
         let videoData;
         //logger.log('nb AVC samples:' + videoTrack.samples.length);
         if (videoTrack.samples.length) {
-          videoData = this.remuxVideo(videoTrack,timeOffset,contiguous, cc);
+          videoData = this.remuxVideo(videoTrack,timeOffset,contiguous);
         }
         if (videoData && audioTrack.codec) {
           this.remuxEmptyAudio(audioTrack, timeOffset, contiguous, videoData);
@@ -170,7 +170,7 @@ class MP4Remuxer {
     }
   }
 
-  remuxVideo(track, timeOffset, contiguous, audioTrackLength, cc) {
+  remuxVideo(track, timeOffset, contiguous, audioTrackLength) {
     var offset = 8,
         pesTimeScale = this.PES_TIMESCALE,
         pes2mp4ScaleFactor = this.PES2MP4SCALEFACTOR,

--- a/tests/unit/helper/level-helper.js
+++ b/tests/unit/helper/level-helper.js
@@ -1,0 +1,57 @@
+const assert = require('assert');
+
+import LevelHelper from '../../../src/helper/level-helper';
+
+const mockReferenceFrag = {
+  start: 20,
+  end: 24,
+  startPTS: 20,
+  endPTS: 24,
+  duration: 4
+};
+
+const mockFrags = [
+  {
+    start: 0,
+    end: 4,
+    startPTS: 0,
+    endPTS: 4,
+    duration: 4
+  },
+  {
+    start: 4,
+    end: 8,
+    startPTS: 4,
+    endPTS: 8,
+    duration: 4
+  }
+];
+
+describe('level-helper', function () {
+  it ('adjusts level fragments using a reference fragment', function () {
+    const details = {
+      fragments: mockFrags.splice(0),
+      PTSKnown: false
+    };
+    const expected = [
+      {
+        start: 20,
+        end: 24,
+        startPTS: 20,
+        endPTS: 24,
+        duration: 4
+      },
+      {
+        start: 24,
+        end: 28,
+        startPTS: 24,
+        endPTS: 28,
+        duration: 4
+      }
+    ];
+
+    LevelHelper.adjustPtsByReferenceFrag(mockReferenceFrag, details);
+    assert.deepEqual(expected, details.fragments);
+    assert.equal(true, details.PTSKnown);
+  });
+});

--- a/tests/unit/helper/level-helper.js
+++ b/tests/unit/helper/level-helper.js
@@ -7,7 +7,8 @@ const mockReferenceFrag = {
   end: 24,
   startPTS: 20,
   endPTS: 24,
-  duration: 4
+  duration: 4,
+  cc: 0,
 };
 
 const mockFrags = [
@@ -16,21 +17,24 @@ const mockFrags = [
     end: 4,
     startPTS: 0,
     endPTS: 4,
-    duration: 4
+    duration: 4,
+    cc: 0,
   },
   {
     start: 4,
     end: 8,
     startPTS: 4,
     endPTS: 8,
-    duration: 4
+    duration: 4,
+    cc: 1
   }
 ];
+
 
 describe('level-helper', function () {
   it ('adjusts level fragments using a reference fragment', function () {
     const details = {
-      fragments: mockFrags.splice(0),
+      fragments: mockFrags,
       PTSKnown: false
     };
     const expected = [
@@ -39,19 +43,136 @@ describe('level-helper', function () {
         end: 24,
         startPTS: 20,
         endPTS: 24,
-        duration: 4
+        duration: 4,
+        cc: 0
       },
       {
         start: 24,
         end: 28,
         startPTS: 24,
         endPTS: 28,
-        duration: 4
+        duration: 4,
+        cc: 1
       }
     ];
 
     LevelHelper.adjustPtsByReferenceFrag(mockReferenceFrag, details);
     assert.deepEqual(expected, details.fragments);
     assert.equal(true, details.PTSKnown);
+  });
+
+  it('finds the first fragment in an array which matches the CC of the first fragment in another array', function () {
+    const prevDetails = {
+      fragments: [mockReferenceFrag, { cc: 1  }]
+    };
+    const curDetails = {
+      fragments: mockFrags
+    };
+    const expected = mockReferenceFrag;
+    const actual = LevelHelper.findDiscontinuousReferenceFrag(prevDetails, curDetails);
+    assert.equal(expected, actual);
+  });
+
+  it('returns undefined if there are no frags in the previous level', function () {
+    const expected = undefined;
+    const actual = LevelHelper.findDiscontinuousReferenceFrag({ fragments: [] }, { fragments: mockFrags });
+    assert.equal(expected, actual);
+  });
+
+  it('returns undefined if there are no matching frags in the previous level', function () {
+    const expected = undefined;
+    const actual = LevelHelper.findDiscontinuousReferenceFrag({ fragments: [{ cc: 10 }] }, { fragments: mockFrags });
+    assert.equal(expected, actual);
+  });
+
+  it('returns undefined if there are no frags in the current level', function () {
+    const expected = undefined;
+    const actual = LevelHelper.findDiscontinuousReferenceFrag({ fragments: [{ cc: 0 }] }, { fragments: [] });
+    assert.equal(expected, actual);
+  });
+
+  it('should align current level when CC increases within the level', function () {
+    const lastLevel = {
+      details: {}
+    };
+    const curDetails = {
+      startCC: 0,
+      endCC: 1
+    };
+
+    const actual = LevelHelper.shouldAlignOnDiscontinuities(null, lastLevel, curDetails);
+    assert.equal(true, actual);
+  });
+
+  it('should align current level when CC increases from last frag to current level', function () {
+    const lastLevel = {
+      details: {}
+    };
+    const lastFrag = {
+      cc: 0
+    };
+    const curDetails = {
+      startCC: 1,
+      endCC: 1
+    };
+
+    const actual = LevelHelper.shouldAlignOnDiscontinuities(lastFrag, lastLevel, curDetails);
+    assert.equal(true, actual);
+  });
+
+  it('should not align when there is no CC increase', function () {
+    const lastLevel = {
+      details: {}
+    };
+    const curDetails = {
+      startCC: 1,
+      endCC: 1
+    };
+    const lastFrag = {
+      cc: 1
+    };
+
+    const actual = LevelHelper.shouldAlignOnDiscontinuities(lastFrag, lastLevel, curDetails);
+    assert.equal(false, actual);
+  });
+
+  it('should not align when there is no previous level', function () {
+    const curDetails = {
+      startCC: 1,
+      endCC: 1
+    };
+    const lastFrag = {
+      cc: 1
+    };
+
+    const actual = LevelHelper.shouldAlignOnDiscontinuities(lastFrag, null, curDetails);
+    assert.equal(false, actual);
+  });
+
+  it('should not align when there are no previous level details', function () {
+    const lastLevel = {
+    };
+    const curDetails = {
+      startCC: 1,
+      endCC: 1
+    };
+    const lastFrag = {
+      cc: 1
+    };
+
+    const actual = LevelHelper.shouldAlignOnDiscontinuities(lastFrag, lastLevel, curDetails);
+    assert.equal(false, actual);
+  });
+
+  it('should not align when there are no current level details', function () {
+    const lastLevel = {
+      details: {}
+    };
+    const lastFrag = {
+      cc: 1
+    };
+
+    const actual = LevelHelper.shouldAlignOnDiscontinuities(lastFrag, lastLevel, null);
+    assert.equal(false, actual);
   });
 });

--- a/tests/unit/helper/level-helper.js
+++ b/tests/unit/helper/level-helper.js
@@ -34,7 +34,7 @@ const mockFrags = [
 describe('level-helper', function () {
   it ('adjusts level fragments using a reference fragment', function () {
     const details = {
-      fragments: mockFrags,
+      fragments: mockFrags.slice(0),
       PTSKnown: false
     };
     const expected = [
@@ -59,6 +59,17 @@ describe('level-helper', function () {
     LevelHelper.adjustPtsByReferenceFrag(mockReferenceFrag, details);
     assert.deepEqual(expected, details.fragments);
     assert.equal(true, details.PTSKnown);
+  });
+
+  it ('does not adjust level fragments if there is no reference frag', function () {
+    const details = {
+      fragments: mockFrags.slice(0),
+      PTSKnown: false
+    };
+
+    LevelHelper.adjustPtsByReferenceFrag(undefined, details);
+    assert.deepEqual(mockFrags, details.fragments);
+    assert.equal(false, details.PTSKnown);
   });
 
   it('finds the first fragment in an array which matches the CC of the first fragment in another array', function () {


### PR DESCRIPTION
When switching to a level which has a) different SNs and b) discontinuities (new CC values), the current level looses alignment with play head. If we detect a change in CC value, attempt to align the new fragments by using the PTS of the first known fragment with the same CC in the previous level.

Todo:
- Get test stream that third parties can use to verify

JW7-3199