### PR TITLE
Only reuse subtitle tracks

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -17,7 +17,8 @@ function clearCurrentCues(track) {
 }
 
 function reuseVttTextTrack(inUseTrack, manifestTrack) {
-  return inUseTrack && inUseTrack.label === manifestTrack.name && !(inUseTrack.textTrack1 || inUseTrack.textTrack2);
+  return inUseTrack && (!inUseTrack._id || /^subtitle/.test(inUseTrack._id)) &&
+    inUseTrack.label === manifestTrack.name && !(inUseTrack.textTrack1 || inUseTrack.textTrack2);
 }
 
 function intersection(x1, x2, y1, y2) {


### PR DESCRIPTION
JW7-3890

### Description of the Changes

A more specific check to determine if a manifest subtitle track with the same label already exists on the video. 

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
