### PR TITLE
Force alignment of audio and video stream CC

### DIFF
--- a/src/utils/discontinuities.js
+++ b/src/utils/discontinuities.js
@@ -1,0 +1,13 @@
+import BinarySearch from './binary-search';
+
+export function findFragWithCC(fragments, CC) {
+  return BinarySearch.search(fragments, (candidate) => {
+     if (candidate.cc < CC) {
+        return 1;
+      } else if (candidate.cc > CC) {
+        return -1;
+     } else {
+        return 0;
+     }
+  });
+}


### PR DESCRIPTION
This PR fixes a problem found in streams with separate audio/video tracks and discontinuities. Current behavior allows for the `audio-stream-controller` to choose a fragment with a different `CC` than the `stream-controller`. This causes the `audio-stream-controller` to enter the `WAITING_INIT_PTS` state and never exit - `INIT_PTS_FOUND` is dispatched from the remuxer but it's found for a different CC.

With these changes, the `audio-stream-controller` now keeps track of the current CC of the `stream-controller`, which is updated on `INIT_PTS_FOUND`. If, on `FRAG_LOADED`, the `initPTS` is undefined and the audio `CC` is different than the video `CC`, we reset frag states and resume the `IDLE` state to force an audio reload. In the `IDLE` state handler we run a binary search to find any fragment matching the `CC` of the video track, and use this to then resolve the correct load position of the audio stream.

This is still a work in progress. An issue I've been seeing is a `FRAG_LOOP_LOADING` error caused by rapid frag loading when the `initPTS` has not yet arrived. This algorithm does not differentiate the case when we've received the "wrong" PTS and when the PTS has not yet arrived.

This issue is inadvertently fixed in the latest (0.7.4) branch of hls.js. There's a bug which pushes the frag to the demuxer even when we do not have an initPTS.

Test stream: https://b028.wpc.azureedge.net/80B028/Samples/a38e6323-95e9-4f1f-9b38-75eba91704e4/5f2ce531-d508-49fb-8152-647eba422aec.ism/Manifest(format=m3u8-aapl)

JW7-4189