### PR TITLE
Ensure we backtrack to the previous fragment

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -451,8 +451,10 @@ class StreamController extends EventHandler {
            // Reset the dropped count now since it won't be reset until we parse the fragment again, which prevents infinite backtracking on the same segment
            logger.warn('Loaded fragment with dropped frames, backtracking 1 segment to find a keyframe');
            frag.dropped = 0;
-           if (prevFrag && prevFrag.loadCounter) {
-             prevFrag.loadCounter--;
+           if (prevFrag) {
+             if (prevFrag.loadCounter) {
+               prevFrag.loadCounter--;
+             }
              frag = prevFrag;
            } else {
              frag = null;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -429,7 +429,7 @@ class StreamController extends EventHandler {
             // and if previous remuxed fragment did not start with a keyframe. (fragPrevious.dropped)
             // let's try to load previous fragment again to get last keyframe
             // then we will reload again current fragment (that way we should be able to fill the buffer hole ...)
-            if (deltaPTS && deltaPTS > config.maxBufferHole && fragPrevious.dropped && curSNIdx && !frag.backtracked) {
+            if (deltaPTS && deltaPTS > config.maxBufferHole && fragPrevious.dropped && curSNIdx) {
               frag = prevFrag;
               logger.warn(`SN just loaded, with large PTS gap between audio and video, maybe frag is not starting with a keyframe ? load previous one to try to overcome this`);
               // decrement previous frag load counter to avoid frag loop loading error when next fragment will get reloaded

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -429,7 +429,7 @@ class StreamController extends EventHandler {
             // and if previous remuxed fragment did not start with a keyframe. (fragPrevious.dropped)
             // let's try to load previous fragment again to get last keyframe
             // then we will reload again current fragment (that way we should be able to fill the buffer hole ...)
-            if (deltaPTS && deltaPTS > config.maxBufferHole && fragPrevious.dropped && curSNIdx) {
+            if (deltaPTS && deltaPTS > config.maxBufferHole && fragPrevious.dropped && curSNIdx && !frag.backtracked) {
               frag = prevFrag;
               logger.warn(`SN just loaded, with large PTS gap between audio and video, maybe frag is not starting with a keyframe ? load previous one to try to overcome this`);
               // decrement previous frag load counter to avoid frag loop loading error when next fragment will get reloaded


### PR DESCRIPTION
In some cases, we can backtrack to the same fragment instead of the previous. This causes unexpected behavior - issues seen were backtracking on the wrong fragment, or crashing due to large PTS gap.