### PR TITLE
Capture CLOSED-CAPTIONS type from master manifest

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -46,6 +46,7 @@ class TimelineController extends EventHandler {
     this.unparsedVttFrags = [];
     this.initPTS = undefined;
     this.cueRanges = [];
+    this.manifestCaptionsLabels = {};
 
     if (this.config.enableCEA708Captions)
     {
@@ -74,7 +75,9 @@ class TimelineController extends EventHandler {
             var existingTrack1 = self.getExistingTrack('1');
             if (!existingTrack1)
             {
-              self.textTrack1 = self.createTextTrack('captions', 'English', 'en');
+              var track1Label = self.manifestCaptionsLabels.captionsTextTrack1Label || 'English';
+              var track1Lang = self.manifestCaptionsLabels.captionsTextTrack1Language || 'en';
+              self.textTrack1 = self.createTextTrack('captions', track1Label, track1Lang);
               self.textTrack1.textTrack1 = true;
             }
             else
@@ -98,7 +101,9 @@ class TimelineController extends EventHandler {
             var existingTrack2 = self.getExistingTrack('2');
             if (!existingTrack2)
             {
-              self.textTrack2 = self.createTextTrack('captions', 'Spanish', 'es');
+              var track2Label = self.manifestCaptionsLabels.captionsTextTrack2Label || 'Español';
+              var track2Lang = self.manifestCaptionsLabels.captionsTextTrack2Language || 'es';
+              self.textTrack2 = self.createTextTrack('captions', track2Label, track2Lang);
               self.textTrack2.textTrack2 = true;
             }
             else
@@ -200,6 +205,7 @@ class TimelineController extends EventHandler {
     this.unparsedVttFrags = this.unparsedVttFrags || [];
     this.initPTS = undefined;
     this.cueRanges = [];
+    this.manifestCaptionsLabels = {};
 
     if (this.config.enableWebVTT) {
       this.tracks = data.subtitles || [];
@@ -233,10 +239,10 @@ class TimelineController extends EventHandler {
         }
 
         index = instreamIdMatch[1];
-        this.config['captionsTextTrack' + index + 'Label'] = captionsTrack.name;
+        this.manifestCaptionsLabels['captionsTextTrack' + index + 'Label'] = captionsTrack.name;
 
         if (captionsTrack.lang) { // optional attribute
-          this.config['captionsTextTrack' + index + 'LanguageCode'] = captionsTrack.lang;
+          this.manifestCaptionsLabels['captionsTextTrack' + index + 'LanguageCode'] = captionsTrack.lang;
         }
       }
     }

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -207,16 +207,38 @@ class TimelineController extends EventHandler {
 
       this.tracks.forEach((track, index) => {
         let textTrack;
-        const inUseTrack = inUseTracks[index];
-        // Reuse tracks with the same label, but do not reuse 608/708 tracks
-        if (reuseVttTextTrack(inUseTrack, track)) {
-          textTrack = inUseTrack;
-        } else {
-          textTrack = this.createTextTrack('subtitles', track.name, track.lang);
+      const inUseTrack = inUseTracks[index];
+      // Reuse tracks with the same label, but do not reuse 608/708 tracks
+      if (reuseVttTextTrack(inUseTrack, track)) {
+        textTrack = inUseTrack;
+      } else {
+        textTrack = this.createTextTrack('subtitles', track.name, track.lang);
+      }
+      textTrack.mode = track.default ? 'showing' : 'hidden';
+      this.textTracks.push(textTrack);
+    });
+    }
+
+    if (this.config.enableCEA708Captions && data.captions) {
+      let captionsTrack;
+      let index;
+      let instreamIdMatch;
+
+      for (let i = 0; i < data.captions.length; i++) {
+        captionsTrack = data.captions[i];
+        instreamIdMatch = /(?:CC|SERVICE)([1-2])/.exec(captionsTrack.instreamId);
+
+        if (!instreamIdMatch) {
+          continue;
         }
-        textTrack.mode = track.default ? 'showing' : 'hidden';
-        this.textTracks.push(textTrack);
-      });
+
+        index = instreamIdMatch[1];
+        this.config['captionsTextTrack' + index + 'Label'] = captionsTrack.name;
+
+        if (captionsTrack.lang) { // optional attribute
+          this.config['captionsTextTrack' + index + 'LanguageCode'] = captionsTrack.lang;
+        }
+      }
     }
   }
 

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -51,6 +51,7 @@ class TimelineController extends EventHandler {
     if (this.config.enableCEA708Captions)
     {
       var self = this;
+      var captionsLabels = this.manifestCaptionsLabels;
       var sendAddTrackEvent = function (track, media)
       {
         var e = null;
@@ -75,9 +76,8 @@ class TimelineController extends EventHandler {
             var existingTrack1 = self.getExistingTrack('1');
             if (!existingTrack1)
             {
-              var track1Label = self.manifestCaptionsLabels.captionsTextTrack1Label || 'English';
-              var track1Lang = self.manifestCaptionsLabels.captionsTextTrack1Language || 'en';
-              self.textTrack1 = self.createTextTrack('captions', track1Label, track1Lang);
+              self.textTrack1 = self.createTextTrack('captions', captionsLabels.captionsTextTrack1Label,
+                captionsLabels.captionsTextTrack1LanguageCode);
               self.textTrack1.textTrack1 = true;
             }
             else
@@ -101,9 +101,8 @@ class TimelineController extends EventHandler {
             var existingTrack2 = self.getExistingTrack('2');
             if (!existingTrack2)
             {
-              var track2Label = self.manifestCaptionsLabels.captionsTextTrack2Label || 'Español';
-              var track2Lang = self.manifestCaptionsLabels.captionsTextTrack2Language || 'es';
-              self.textTrack2 = self.createTextTrack('captions', track2Label, track2Lang);
+              self.textTrack2 = self.createTextTrack('captions', captionsLabels.captionsTextTrack2Label,
+                captionsLabels.captionsTextTrack2LanguageCode);
               self.textTrack2.textTrack2 = true;
             }
             else
@@ -205,7 +204,12 @@ class TimelineController extends EventHandler {
     this.unparsedVttFrags = this.unparsedVttFrags || [];
     this.initPTS = undefined;
     this.cueRanges = [];
-    this.manifestCaptionsLabels = {};
+    var captionsLabels = this.manifestCaptionsLabels;
+
+    captionsLabels.captionsTextTrack1Label = 'English';
+    captionsLabels.captionsTextTrack1LanguageCode = 'en';
+    captionsLabels.captionsTextTrack2Label = 'Español';
+    captionsLabels.captionsTextTrack2LanguageCode = 'es';
 
     if (this.config.enableWebVTT) {
       this.tracks = data.subtitles || [];
@@ -226,25 +230,23 @@ class TimelineController extends EventHandler {
     }
 
     if (this.config.enableCEA708Captions && data.captions) {
-      let captionsTrack;
       let index;
       let instreamIdMatch;
 
-      for (let i = 0; i < data.captions.length; i++) {
-        captionsTrack = data.captions[i];
+      data.captions.forEach(function (captionsTrack) {
         instreamIdMatch = /(?:CC|SERVICE)([1-2])/.exec(captionsTrack.instreamId);
 
         if (!instreamIdMatch) {
-          continue;
+          return;
         }
 
         index = instreamIdMatch[1];
-        this.manifestCaptionsLabels['captionsTextTrack' + index + 'Label'] = captionsTrack.name;
+        captionsLabels['captionsTextTrack' + index + 'Label'] = captionsTrack.name;
 
         if (captionsTrack.lang) { // optional attribute
-          this.manifestCaptionsLabels['captionsTextTrack' + index + 'LanguageCode'] = captionsTrack.lang;
+          captionsLabels['captionsTextTrack' + index + 'LanguageCode'] = captionsTrack.lang;
         }
-      }
+      });
     }
   }
 

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -255,6 +255,7 @@ class PlaylistLoader extends EventHandler {
       var attrs = new AttrList(result[1]);
       if(attrs.TYPE === type) {
         media.groupId = attrs['GROUP-ID'];
+        media.instreamId = attrs['INSTREAM-ID'];
         media.name = attrs.NAME;
         media.type = type;
         media.default = (attrs.DEFAULT === 'YES');
@@ -484,6 +485,7 @@ class PlaylistLoader extends EventHandler {
         if (levels.length) {
           let audioTracks = this.parseMasterPlaylistMedia(string, url, 'AUDIO');
           let subtitles = this.parseMasterPlaylistMedia(string, url, 'SUBTITLES');
+          let captions = this.parseMasterPlaylistMedia(string, url, 'CLOSED-CAPTIONS');
           if (audioTracks.length) {
             // check if we have found an audio track embedded in main playlist (audio track without URI attribute)
             let embeddedAudioFound = false;
@@ -499,7 +501,7 @@ class PlaylistLoader extends EventHandler {
               audioTracks.unshift({ type : 'main', name : 'main'});
             }
           }
-          hls.trigger(Event.MANIFEST_LOADED, {levels, audioTracks, subtitles, url, stats});
+          hls.trigger(Event.MANIFEST_LOADED, {levels, audioTracks, subtitles, captions, url, stats});
         } else {
           hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_EMPTY_ERROR, fatal: false, url: url, reason: 'no level found in manifest', context });
         }


### PR DESCRIPTION
### Description of the Changes
When `EXT-X-MEDIA` has a `CLOSED-CAPTIONS` type, capture the name (required) and language (optional) so that the captions menu reflects the track info specified in the master manifest.

JW7-4250
