### PR TITLE
Fire manifestParsingError if master manifest has no levels

### DIFF
--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -505,7 +505,7 @@ class PlaylistLoader extends EventHandler {
           }
           hls.trigger(Event.MANIFEST_LOADED, {levels, audioTracks, subtitles, captions, url, stats});
         } else {
-          if (context.type === 'manifest') {
+          if (type === 'manifest') {
             hls.trigger(Event.ERROR, {
               type: ErrorTypes.NETWORK_ERROR,
               details: ErrorDetails.MANIFEST_PARSING_ERROR,

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -505,7 +505,17 @@ class PlaylistLoader extends EventHandler {
           }
           hls.trigger(Event.MANIFEST_LOADED, {levels, audioTracks, subtitles, captions, url, stats});
         } else {
-          hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_EMPTY_ERROR, fatal: false, url: url, reason: 'no level found in manifest', context });
+          if (context.type === 'manifest') {
+            hls.trigger(Event.ERROR, {
+              type: ErrorTypes.NETWORK_ERROR,
+              details: ErrorDetails.MANIFEST_PARSING_ERROR,
+              fatal: true,
+              url: url,
+              reason: 'no level found in manifest'
+            });
+          } else {
+            hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_EMPTY_ERROR, fatal: false, url: url, reason: 'no level found in manifest', context });
+          }
         }
       }
     } else {


### PR DESCRIPTION
`context.type` in the `loadsuccess` handler tells us if the loaded media is a level or manifest. If a manifest is empty, fire a fatal `manifestParsingError`. Otherwise, fire a non-fatal `levelEmptyError`.

JW7-4271