### PR TITLE
Allow custom render VTTCues if captions aren't intended to be rendered natively

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -257,7 +257,7 @@ class TimelineController extends EventHandler {
           this.textTracks.push(textTrack);
         });
       } else if (!sameTracks) {
-        // Coverts tracks to a flash-like list for consumption
+        // Create a list of tracks for the provider to consume
         let tracksList = this.tracks.map((track) => {
           return {
             'label': track.name,

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -101,7 +101,7 @@ class TimelineController extends EventHandler {
               self.sendAddTrackEvent(self.textTrack1, self.media);
             }
           }
-          self.addCues('textTrack1', startTime, endTime, screen, self.sendAddCueEvent);
+          self.addCues('textTrack1', startTime, endTime, screen);
         }
       };
 
@@ -127,7 +127,7 @@ class TimelineController extends EventHandler {
               self.sendAddTrackEvent(self.textTrack2, self.media);
             }
           }
-          self.addCues('textTrack2', startTime, endTime, screen, self.sendAddCueEvent);
+          self.addCues('textTrack2', startTime, endTime, screen);
         }
       };
 
@@ -135,7 +135,7 @@ class TimelineController extends EventHandler {
     }
   }
 
-  addCues(channel, startTime, endTime, screen, sendAddCueFunc) {
+  addCues(channel, startTime, endTime, screen) {
     // skip cues which overlap more than 50% with previously parsed time ranges
     const ranges = this.cueRanges;
     let merged = false;
@@ -154,11 +154,13 @@ class TimelineController extends EventHandler {
     if (!merged) {
       ranges.push([startTime, endTime]);
     }
-    var cues = this.Cues.newCues(startTime, endTime, screen);
-    if (cues && this.config.renderNatively) {
+
+    let cues = this.Cues.createCues(startTime, endTime, screen);
+    let self = this;
+    if (this.config.renderNatively) {
       cues.forEach((cue) => { this[channel].addCue(cue); });
     } else {
-      cues.forEach((cue) => { sendAddCueFunc({ type: 'captions', cue: cue }); });
+      cues.forEach((cue) => { self.sendAddCueEvent({ type: 'captions', cue: cue }); });
     }
   }
 
@@ -319,15 +321,11 @@ class TimelineController extends EventHandler {
 
         // Parse the WebVTT file contents.
         WebVTTParser.parse(payload, this.initPTS, vttCCs, frag.cc, function (cues) {
-            // Add cues and trigger event with success true.
-            cues.forEach(cue => {
-              // Change from captions
-              if (self.config.renderNatively) {
-                textTracks[frag.trackId].addCue(cue);
-              } else {
-                self.sendAddCueEvent({ type: 'captions', track: textTracks[frag.trackId]._id, cue: cue });
-              }
-            });
+            if (self.config.renderNatively) {
+              cues.forEach(cue => { textTracks[frag.trackId].addCue(cue) });
+            } else {
+              cues.forEach(cue => { self.sendAddCueEvent({ type: 'captions', track: textTracks[frag.trackId]._id, cue: cue })} );
+            }
             hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, { success: true, frag: frag });
           },
           function (e) {

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -65,6 +65,19 @@ class TimelineController extends EventHandler {
         e.track = track;
         media.dispatchEvent(e);
       };
+      var sendAddCueEvent = function (cueData)
+      {
+        var e = null;
+        try {
+          e = new window.Event('addcue');
+        } catch (err) {
+          //for IE11
+          e = document.createEvent('Event');
+          e.initEvent('addcue', false, false);
+        }
+        e.cueData = cueData;
+        self.media.dispatchEvent(e);
+      };
 
       var channel1 =
       {
@@ -88,7 +101,7 @@ class TimelineController extends EventHandler {
               sendAddTrackEvent(self.textTrack1, self.media);
             }
           }
-          self.addCues('textTrack1', startTime, endTime, screen);
+          self.addCues('textTrack1', startTime, endTime, screen, sendAddCueEvent);
         }
       };
 
@@ -114,7 +127,7 @@ class TimelineController extends EventHandler {
               sendAddTrackEvent(self.textTrack2, self.media);
             }
           }
-          self.addCues('textTrack2', startTime, endTime, screen);
+          self.addCues('textTrack2', startTime, endTime, screen, sendAddCueEvent);
         }
       };
 
@@ -122,7 +135,7 @@ class TimelineController extends EventHandler {
     }
   }
 
-  addCues(channel, startTime, endTime, screen) {
+  addCues(channel, startTime, endTime, screen, sendAddCueEventCb) {
     // skip cues which overlap more than 50% with previously parsed time ranges
     const ranges = this.cueRanges;
     let merged = false;
@@ -141,7 +154,7 @@ class TimelineController extends EventHandler {
     if (!merged) {
       ranges.push([startTime, endTime]);
     }
-    this.Cues.newCue(this[channel], startTime, endTime, screen);
+    this.Cues.newCue(this[channel], startTime, endTime, screen, sendAddCueEventCb);
   }
 
   // Triggered when an initial PTS is found; used for synchronisation of WebVTT.

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -25,6 +25,10 @@ function intersection(x1, x2, y1, y2) {
   return Math.min(x2, y2) - Math.max(x1, y1);
 }
 
+const sendCustomEvent = (eventName, payload, emitter) => {
+  emitter.trigger(eventName, payload);
+};
+
 class TimelineController extends EventHandler {
 
   constructor(hls) {
@@ -369,9 +373,5 @@ class TimelineController extends EventHandler {
     return actualCCBytes;
   }
 }
-
-const sendCustomEvent = (eventName, payload, emitter) => {
-  emitter.trigger(eventName, payload);
-};
 
 export default TimelineController;

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -329,7 +329,7 @@ class TimelineController extends EventHandler {
             if (self.config.renderNatively) {
               cues.forEach(cue => { tracks[frag.trackId].addCue(cue); });
             } else {
-              cues.forEach(cue => { this.hls.trigger(Event.CUE_PARSED, { cueData: { type: 'subtitles', track: 'subtitles'+frag.trackId, cue: cue } }); });
+              cues.forEach(cue => { self.hls.trigger(Event.CUE_PARSED, { cueData: { type: 'subtitles', track: 'subtitles'+frag.trackId, cue: cue } }); });
             }
             hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, { success: true, frag: frag });
           },

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -60,7 +60,7 @@ class TimelineController extends EventHandler {
       e.track = track;
       media.dispatchEvent(e);
     };
-    this.sendAddCueEvent = function (cueData)
+    this.sendAddCueEvent = function (cueData, media)
     {
       var e = null;
       try {
@@ -71,12 +71,11 @@ class TimelineController extends EventHandler {
         e.initEvent('addcue', false, false);
       }
       e.cueData = cueData;
-      self.media.dispatchEvent(e);
+      media.dispatchEvent(e);
     };
 
     if (this.config.enableCEA708Captions)
     {
-      var self = this;
       var captionsLabels = this.manifestCaptionsLabels;
 
       var channel1 =
@@ -160,7 +159,7 @@ class TimelineController extends EventHandler {
     if (this.config.renderNatively) {
       cues.forEach((cue) => { this[channel].addCue(cue); });
     } else {
-      cues.forEach((cue) => { self.sendAddCueEvent({ type: 'captions', cue: cue }); });
+      cues.forEach((cue) => { self.sendAddCueEvent({ type: 'captions', cue: cue }, self.media); });
     }
   }
 
@@ -322,9 +321,9 @@ class TimelineController extends EventHandler {
         // Parse the WebVTT file contents.
         WebVTTParser.parse(payload, this.initPTS, vttCCs, frag.cc, function (cues) {
             if (self.config.renderNatively) {
-              cues.forEach(cue => { textTracks[frag.trackId].addCue(cue) });
+              cues.forEach(cue => { textTracks[frag.trackId].addCue(cue); });
             } else {
-              cues.forEach(cue => { self.sendAddCueEvent({ type: 'captions', track: textTracks[frag.trackId]._id, cue: cue })} );
+              cues.forEach(cue => { self.sendAddCueEvent({ type: 'captions', track: textTracks[frag.trackId]._id, cue: cue }, self.media); } );
             }
             hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, { success: true, frag: frag });
           },

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -25,10 +25,6 @@ function intersection(x1, x2, y1, y2) {
   return Math.min(x2, y2) - Math.max(x1, y1);
 }
 
-const sendCustomEvent = (eventName, payload, emitter) => {
-  emitter.trigger(eventName, payload);
-};
-
 class TimelineController extends EventHandler {
 
   constructor(hls) {
@@ -57,54 +53,70 @@ class TimelineController extends EventHandler {
       var self = this;
       var captionsLabels = this.manifestCaptionsLabels;
 
-      var channel1 =
-      {
-        'newCue': function(startTime, endTime, screen)
-        {
-          if (!self.textTrack1)
-          {
-            //Enable reuse of existing text track.
-            var existingTrack1 = self.getExistingTrack('1');
-            if (!existingTrack1)
-            {
-              self.textTrack1 = self.createTextTrack('captions', captionsLabels.captionsTextTrack1Label,
-                captionsLabels.captionsTextTrack1LanguageCode);
-              self.textTrack1.textTrack1 = true;
-            }
-            else
-            {
-              self.textTrack1 = existingTrack1;
-              clearCurrentCues(self.textTrack1);
+      var channel1 = {
+        'newCue': function(startTime, endTime, screen) {
+          if (!self.textTrack1) {
+            if (self.config.renderNatively) {
+              //Enable reuse of existing text track.
+              var existingTrack1 = self.getExistingTrack('1');
+              if (!existingTrack1) {
+                self.textTrack1 = self.createTextTrack('captions', captionsLabels.captionsTextTrack1Label,
+                  captionsLabels.captionsTextTrack1LanguageCode);
+                self.textTrack1.textTrack1 = true;
+              } else {
+                self.textTrack1 = existingTrack1;
+                clearCurrentCues(self.textTrack1);
 
-              sendCustomEvent('addtrack', {track: self.textTrack1}, self.hls);
+                let event = new window.Event('addtrack');
+                event.track = self.textTrack1;
+                self.media.dispatchEvent(event);
+              }
+            } else {
+              // Create a list of a single track for the provider to consume
+              self.textTrack1 = {
+                '_id': 'textTrack1',
+                'label': captionsLabels.captionsTextTrack1Label,
+                'kind': 'captions',
+                'default': false
+              };
+              self.hls.trigger(Event.NON_NATIVE_TEXT_TRACKS_FOUND, { tracks: [ self.textTrack1] });
             }
           }
+
           self.addCues('textTrack1', startTime, endTime, screen);
         }
       };
 
-      var channel2 =
-      {
-        'newCue': function(startTime, endTime, screen)
-        {
-          if (!self.textTrack2)
-          {
-            //Enable reuse of existing text track.
-            var existingTrack2 = self.getExistingTrack('2');
-            if (!existingTrack2)
-            {
-              self.textTrack2 = self.createTextTrack('captions', captionsLabels.captionsTextTrack2Label,
-                captionsLabels.captionsTextTrack2LanguageCode);
-              self.textTrack2.textTrack2 = true;
-            }
-            else
-            {
-              self.textTrack2 = existingTrack2;
-              clearCurrentCues(self.textTrack2);
+      var channel2 = {
+        'newCue': function(startTime, endTime, screen) {
+          if (!self.textTrack2) {
+            if (self.config.renderNatively) {
+              //Enable reuse of existing text track.
+              var existingTrack2 = self.getExistingTrack('2');
+              if (!existingTrack2) {
+                self.textTrack2 = self.createTextTrack('captions', captionsLabels.captionsTextTrack2Label,
+                  captionsLabels.captionsTextTrack2LanguageCode);
+                self.textTrack2.textTrack2 = true;
+              } else {
+                self.textTrack2 = existingTrack2;
+                clearCurrentCues(self.textTrack2);
 
-              sendCustomEvent('addtrack', {track: self.textTrack2}, self.hls);
+                let event = new window.Event('addtrack');
+                event.track = self.textTrack2;
+                self.media.dispatchEvent(event);
+              }
+            } else {
+              // Create a list of a single track for the provider to consume
+              self.textTrack2 = {
+                '_id': 'textTrack2',
+                'label': captionsLabels.captionsTextTrack2Label,
+                'kind': 'captions',
+                'default': false
+              };
+              self.hls.trigger(Event.NON_NATIVE_TEXT_TRACKS_FOUND, { tracks: [ self.textTrack2] });
             }
           }
+
           self.addCues('textTrack2', startTime, endTime, screen);
         }
       };
@@ -137,7 +149,7 @@ class TimelineController extends EventHandler {
     if (this.config.renderNatively) {
       cues.forEach((cue) => { this[channel].addCue(cue); });
     } else {
-      cues.forEach((cue) => { sendCustomEvent('addcue', {track: this[channel], cueData: { type: 'captions', cue: cue }}, this.hls); });
+      cues.forEach((cue) => { this.hls.trigger(Event.CUE_PARSED, { cueData: { type: 'captions', cue: cue, track: channel } }); });
     }
   }
 
@@ -249,11 +261,11 @@ class TimelineController extends EventHandler {
         let tracksList = this.tracks.map((track) => {
           return {
             'label': track.name,
-            'kind': track.type.toLowerCase(), /*'file': track.url,*/
+            'kind': track.type.toLowerCase(),
             'default': track.default
           };
         });
-        this.hls.trigger('jwplayerRenderedSubtitleTracks', tracksList);
+        this.hls.trigger(Event.NON_NATIVE_TEXT_TRACKS_FOUND, { tracks: tracksList });
       }
     }
 
@@ -317,7 +329,7 @@ class TimelineController extends EventHandler {
             if (self.config.renderNatively) {
               cues.forEach(cue => { tracks[frag.trackId].addCue(cue); });
             } else {
-              cues.forEach(cue => { sendCustomEvent('addcue', {cueData: { type: 'captions', track: 'subtitles'+frag.trackId, cue: cue }}, self.hls); });
+              cues.forEach(cue => { this.hls.trigger(Event.CUE_PARSED, { cueData: { type: 'subtitles', track: 'subtitles'+frag.trackId, cue: cue } }); });
             }
             hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, { success: true, frag: frag });
           },

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -76,6 +76,7 @@ class TimelineController extends EventHandler {
 
     if (this.config.enableCEA708Captions)
     {
+      var self = this;
       var captionsLabels = this.manifestCaptionsLabels;
 
       var channel1 =

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -47,32 +47,6 @@ class TimelineController extends EventHandler {
     this.initPTS = undefined;
     this.cueRanges = [];
     this.manifestCaptionsLabels = {};
-    this.sendAddTrackEvent = function (track, media)
-    {
-      var e = null;
-      try {
-        e = new window.Event('addtrack');
-      } catch (err) {
-        //for IE11
-        e = document.createEvent('Event');
-        e.initEvent('addtrack', false, false);
-      }
-      e.track = track;
-      media.dispatchEvent(e);
-    };
-    this.sendAddCueEvent = function (cueData, media)
-    {
-      var e = null;
-      try {
-        e = new window.Event('addcue');
-      } catch (err) {
-        //for IE11
-        e = document.createEvent('Event');
-        e.initEvent('addcue', false, false);
-      }
-      e.cueData = cueData;
-      media.dispatchEvent(e);
-    };
 
     if (this.config.enableCEA708Captions)
     {
@@ -98,7 +72,7 @@ class TimelineController extends EventHandler {
               self.textTrack1 = existingTrack1;
               clearCurrentCues(self.textTrack1);
 
-              self.sendAddTrackEvent(self.textTrack1, self.media);
+              sendCustomEvent('addtrack', {track: self.textTrack1}, self.hls);
             }
           }
           self.addCues('textTrack1', startTime, endTime, screen);
@@ -124,7 +98,7 @@ class TimelineController extends EventHandler {
               self.textTrack2 = existingTrack2;
               clearCurrentCues(self.textTrack2);
 
-              self.sendAddTrackEvent(self.textTrack2, self.media);
+              sendCustomEvent('addtrack', {track: self.textTrack2}, self.hls);
             }
           }
           self.addCues('textTrack2', startTime, endTime, screen);
@@ -156,11 +130,10 @@ class TimelineController extends EventHandler {
     }
 
     let cues = this.Cues.createCues(startTime, endTime, screen);
-    let self = this;
     if (this.config.renderNatively) {
       cues.forEach((cue) => { this[channel].addCue(cue); });
     } else {
-      cues.forEach((cue) => { self.sendAddCueEvent({ type: 'captions', cue: cue }, self.media); });
+      cues.forEach((cue) => { sendCustomEvent('addcue', {track: this[channel], cueData: { type: 'captions', cue: cue }}, this.hls); });
     }
   }
 
@@ -217,7 +190,7 @@ class TimelineController extends EventHandler {
 
   onManifestLoading()
   {
-    this.lastSn = -1; // Detect discontiguity in fragment parsing
+    this.lastSn = -1; // Detect discontinuity in fragment parsing
     this.prevCC = -1;
     this.vttCCs = {ccOffset: 0, presentationOffset: 0}; // Detect discontinuity in subtitle manifests
 
@@ -246,24 +219,38 @@ class TimelineController extends EventHandler {
     captionsLabels.captionsTextTrack2LanguageCode = 'es';
 
     if (this.config.enableWebVTT) {
+      const sameTracks = this.tracks && data.subtitles && this.tracks.length === data.subtitles.length;
       this.tracks = data.subtitles || [];
-      const inUseTracks = this.media ? this.media.textTracks : [];
 
-      this.tracks.forEach((track, index) => {
-        let textTrack;
-        if (index < inUseTracks.length) {
-          const inUseTrack = inUseTracks[index];
-          // Reuse tracks with the same label, but do not reuse 608/708 tracks
-          if (reuseVttTextTrack(inUseTrack, track)) {
-            textTrack = inUseTrack;
+      if (this.config.renderNatively) {
+        let inUseTracks = this.media ? this.media.textTracks : [];
+
+        this.tracks.forEach((track, index) => {
+          let textTrack;
+          if (index < inUseTracks.length) {
+            const inUseTrack = inUseTracks[index];
+            // Reuse tracks with the same label, but do not reuse 608/708 tracks
+            if (reuseVttTextTrack(inUseTrack, track)) {
+              textTrack = inUseTrack;
+            }
           }
-        }
-        if (!textTrack) {
-          textTrack = this.createTextTrack('subtitles', track.name, track.lang);
-        }
-        textTrack.mode = track.default ? 'showing' : 'hidden';
-        this.textTracks.push(textTrack);
-      });
+          if (!textTrack) {
+            textTrack = this.createTextTrack('subtitles', track.name, track.lang);
+          }
+          textTrack.mode = track.default ? 'showing' : 'hidden';
+          this.textTracks.push(textTrack);
+        });
+      } else if (!sameTracks) {
+        // Coverts tracks to a flash-like list for consumption
+        let tracksList = this.tracks.map((track) => {
+          return {
+            'label': track.name,
+            'kind': track.type.toLowerCase(), /*'file': track.url,*/
+            'default': track.default
+          };
+        });
+        this.hls.trigger('jwplayerRenderedSubtitleTracks', tracksList);
+      }
     }
 
     if (this.config.enableCEA708Captions && data.captions) {
@@ -292,11 +279,12 @@ class TimelineController extends EventHandler {
   }
 
   onFragLoaded(data) {
-    let frag = data.frag,
-        payload = data.payload,
-        self = this;
+    let frag = data.frag;
+    let payload = data.payload;
+    let self = this;
+
     if (frag.type === 'main') {
-      var sn = frag.sn;
+      let sn = frag.sn;
       // if this frag isn't contiguous, clear the parser so cues with bad start/end times aren't added to the textTrack
       if (sn !== this.lastSn + 1) {
         this.cea608Parser.reset();
@@ -316,15 +304,16 @@ class TimelineController extends EventHandler {
           vttCCs[frag.cc] = { start: frag.start, prevCC: this.prevCC, new: true };
           this.prevCC = frag.cc;
         }
-        let textTracks = this.textTracks,
-          hls = this.hls;
+
+        let hls = this.hls;
+        let tracks = (self.config.renderNatively) ? this.textTracks : this.tracks;
 
         // Parse the WebVTT file contents.
         WebVTTParser.parse(payload, this.initPTS, vttCCs, frag.cc, function (cues) {
             if (self.config.renderNatively) {
-              cues.forEach(cue => { textTracks[frag.trackId].addCue(cue); });
+              cues.forEach(cue => { tracks[frag.trackId].addCue(cue); });
             } else {
-              cues.forEach(cue => { self.sendAddCueEvent({ type: 'captions', track: textTracks[frag.trackId]._id, cue: cue }, self.media); } );
+              cues.forEach(cue => { sendCustomEvent('addcue', {cueData: { type: 'captions', track: 'subtitles'+frag.trackId, cue: cue }}, self.hls); });
             }
             hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, { success: true, frag: frag });
           },
@@ -380,5 +369,9 @@ class TimelineController extends EventHandler {
     return actualCCBytes;
   }
 }
+
+const sendCustomEvent = (eventName, payload, emitter) => {
+  emitter.trigger(eventName, payload);
+};
 
 export default TimelineController;

--- a/src/events.js
+++ b/src/events.js
@@ -67,6 +67,10 @@ module.exports = {
   SUBTITLE_TRACK_LOADED: 'hlsSubtitleTrackLoaded',
   // fired when a subtitle fragment has been processed - data: { success : boolean, frag : the processed frag}
   SUBTITLE_FRAG_PROCESSED: 'hlsSubtitleFragProcessed',
+  // fired when a VTTCue to be managed externally has been parsed - data: { track: TextTrack, cueData: { type: string, cue: VTTCue } }
+  CUE_PARSED: 'hlsCueParsed',
+  // fired when a text track to be managed externally is found - data: { tracks: [ { label: string, kind: string, default: boolean } ] }
+  NON_NATIVE_TEXT_TRACKS_FOUND: 'hlsNonNativeTextTracksFound',
   // fired when the first timestamp is found. - data: { id : demuxer id, initPTS: initPTS , frag : fragment object}
   INIT_PTS_FOUND: 'hlsInitPtsFound',
   // fired when a fragment loading starts - data: { frag : fragment object}

--- a/src/events.js
+++ b/src/events.js
@@ -67,7 +67,7 @@ module.exports = {
   SUBTITLE_TRACK_LOADED: 'hlsSubtitleTrackLoaded',
   // fired when a subtitle fragment has been processed - data: { success : boolean, frag : the processed frag}
   SUBTITLE_FRAG_PROCESSED: 'hlsSubtitleFragProcessed',
-  // fired when a VTTCue to be managed externally has been parsed - data: { track: TextTrack, cueData: { type: string, cue: VTTCue } }
+  // fired when a VTTCue to be managed externally has been parsed - data: { cueData: { type: string, track: string, cue: VTTCue } }
   CUE_PARSED: 'hlsCueParsed',
   // fired when a text track to be managed externally is found - data: { tracks: [ { label: string, kind: string, default: boolean } ] }
   NON_NATIVE_TEXT_TRACKS_FOUND: 'hlsNonNativeTextTracksFound',

--- a/src/utils/cues.js
+++ b/src/utils/cues.js
@@ -61,7 +61,7 @@ const Cues = {
         }
         else
         {
-          cue.line = (r > 7 ? r - 3 : r + 1);
+          cue.line = (r > 7 ? r - 2 : r + 1);
         }
         cue.align = 'left';
         // Clamp the position between 0 and 100 - if out of these bounds, Firefox throws an exception and captions break

--- a/src/utils/cues.js
+++ b/src/utils/cues.js
@@ -1,16 +1,16 @@
 import { fixLineBreaks } from './vttparser';
-//import { VTTCue } from './vttcue';
+import VTTCue from './vttcue';
+
 
 const Cues = {
 
-  newCues: function(startTime, endTime, captionScreen) {
+  createCues: function(startTime, endTime, captionScreen) {
     var row;
     var cue;
     var cues = [];
     var indenting;
     var indent;
     var text;
-    var VTTCue = window.VTTCue || window.TextTrackCue;
 
     for (var r=0; r<captionScreen.rows.length; r++)
     {

--- a/src/utils/cues.js
+++ b/src/utils/cues.js
@@ -61,7 +61,7 @@ const Cues = {
         }
         else
         {
-          cue.line = (r > 7 ? r - 2 : r + 1);
+          cue.line = (r > 7 ? r - 3 : r + 1);
         }
         cue.align = 'left';
         // Clamp the position between 0 and 100 - if out of these bounds, Firefox throws an exception and captions break

--- a/src/utils/cues.js
+++ b/src/utils/cues.js
@@ -1,10 +1,12 @@
 import { fixLineBreaks } from './vttparser';
+//import { VTTCue } from './vttcue';
 
 const Cues = {
 
-  newCue: function(track, startTime, endTime, captionScreen, callback) {
+  newCues: function(startTime, endTime, captionScreen) {
     var row;
     var cue;
+    var cues = [];
     var indenting;
     var indent;
     var text;
@@ -64,13 +66,10 @@ const Cues = {
         cue.align = 'left';
         // Clamp the position between 0 and 100 - if out of these bounds, Firefox throws an exception and captions break
         cue.position = Math.max(0, Math.min(100, 100 * (indent / 32) + (navigator.userAgent.match(/Firefox\//) ? 50 : 0)));
-        track.addCue(cue);
-        callback({
-          type: 'captions',
-          cue: cue
-        });
+        cues.push(cue);
       }
     }
+    return cues;
   }
 
 };

--- a/src/utils/cues.js
+++ b/src/utils/cues.js
@@ -2,7 +2,7 @@ import { fixLineBreaks } from './vttparser';
 
 const Cues = {
 
-  newCue: function(track, startTime, endTime, captionScreen) {
+  newCue: function(track, startTime, endTime, captionScreen, callback) {
     var row;
     var cue;
     var indenting;
@@ -65,6 +65,10 @@ const Cues = {
         // Clamp the position between 0 and 100 - if out of these bounds, Firefox throws an exception and captions break
         cue.position = Math.max(0, Math.min(100, 100 * (indent / 32) + (navigator.userAgent.match(/Firefox\//) ? 50 : 0)));
         track.addCue(cue);
+        callback({
+          type: 'captions',
+          cue: cue
+        });
       }
     }
   }


### PR DESCRIPTION
### Description of the Changes
This PR changes it so that when cues are created, we do not immediately add them to the track, but rather will do so only if they're intended to be rendered natively.  If not, we will send out an event that will allow a custom cue renderer to use them however it sees fit.  It also adds the VTTCue polyfill to the cues.js file so that we can ensure the type of object it creates in browsers like IE11.

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [X] no commits have been done in dist folder (we will take care of updating it)
- [X] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
