### PR TITLE
Remove Firefox code that shifts captions to the side

### DIFF
--- a/src/utils/cues.js
+++ b/src/utils/cues.js
@@ -65,7 +65,7 @@ const Cues = {
         }
         cue.align = 'left';
         // Clamp the position between 0 and 100 - if out of these bounds, Firefox throws an exception and captions break
-        cue.position = Math.max(0, Math.min(100, 100 * (indent / 32) + (navigator.userAgent.match(/Firefox\//) ? 50 : 0)));
+        cue.position = Math.max(0, Math.min(100, 100 * (indent / 32)));
         cues.push(cue);
       }
     }


### PR DESCRIPTION
### What does this Pull Request do?
It removes Firefox specific code that shifts captions to the side unnecessarily

### Why is this Pull Request needed?
Because captions were being shifted very far to the side unnecessarily.  The clamping code that was added previously should protect against any positions that would cause errors in firefox anyways.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer/pull/2024 is somewhat related