### PR TITLE
Send multiple cues in a single event

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -149,7 +149,7 @@ class TimelineController extends EventHandler {
     if (this.config.renderNatively) {
       cues.forEach((cue) => { this[channel].addCue(cue); });
     } else {
-      cues.forEach((cue) => { this.hls.trigger(Event.CUE_PARSED, { cueData: { type: 'captions', cue: cue, track: channel } }); });
+      this.hls.trigger(Event.CUES_PARSED, { type: 'captions', cues: cues, track: channel });
     }
   }
 
@@ -329,7 +329,7 @@ class TimelineController extends EventHandler {
             if (self.config.renderNatively) {
               cues.forEach(cue => { tracks[frag.trackId].addCue(cue); });
             } else {
-              cues.forEach(cue => { self.hls.trigger(Event.CUE_PARSED, { cueData: { type: 'subtitles', track: 'subtitles'+frag.trackId, cue: cue } }); });
+              this.hls.trigger(Event.CUES_PARSED, { type: 'subtitles', cues: cues, track: 'subtitles'+frag.trackId });
             }
             hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, { success: true, frag: frag });
           },

--- a/src/events.js
+++ b/src/events.js
@@ -67,8 +67,8 @@ module.exports = {
   SUBTITLE_TRACK_LOADED: 'hlsSubtitleTrackLoaded',
   // fired when a subtitle fragment has been processed - data: { success : boolean, frag : the processed frag}
   SUBTITLE_FRAG_PROCESSED: 'hlsSubtitleFragProcessed',
-  // fired when a VTTCue to be managed externally has been parsed - data: { cueData: { type: string, track: string, cue: VTTCue } }
-  CUE_PARSED: 'hlsCueParsed',
+  // fired when a set of VTTCues to be managed externally has been parsed - data: { type: string, track: string, cues: [ VTTCue ] }
+  CUES_PARSED: 'hlsCueParsed',
   // fired when a text track to be managed externally is found - data: { tracks: [ { label: string, kind: string, default: boolean } ] }
   NON_NATIVE_TEXT_TRACKS_FOUND: 'hlsNonNativeTextTracksFound',
   // fired when the first timestamp is found. - data: { id : demuxer id, initPTS: initPTS , frag : fragment object}

--- a/src/events.js
+++ b/src/events.js
@@ -68,7 +68,7 @@ module.exports = {
   // fired when a subtitle fragment has been processed - data: { success : boolean, frag : the processed frag}
   SUBTITLE_FRAG_PROCESSED: 'hlsSubtitleFragProcessed',
   // fired when a set of VTTCues to be managed externally has been parsed - data: { type: string, track: string, cues: [ VTTCue ] }
-  CUES_PARSED: 'hlsCueParsed',
+  CUES_PARSED: 'hlsCuesParsed',
   // fired when a text track to be managed externally is found - data: { tracks: [ { label: string, kind: string, default: boolean } ] }
   NON_NATIVE_TEXT_TRACKS_FOUND: 'hlsNonNativeTextTracksFound',
   // fired when the first timestamp is found. - data: { id : demuxer id, initPTS: initPTS , frag : fragment object}


### PR DESCRIPTION
### What does this Pull Request do?
This PR makes it so that we send multiple VTT cues in a single event to reduce the number of events passes between HLSJS and the rest of the player.

### Why is this Pull Request needed?
This improve efficency by reducing unnecessary event traffic between HLSJS and the rest of the player.
Also flattens the object used to communicate cues since it was unnecessarily nested.

### Are there any Pull Requests open in other repos which need to be merged with this?
Yes, https://github.com/jwplayer/jwplayer-commercial/pull/3394