### PR TITLE
Pass along the track id for parsed subtitle cues

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -329,7 +329,9 @@ class TimelineController extends EventHandler {
             if (self.config.renderNatively) {
               cues.forEach(cue => { tracks[frag.trackId].addCue(cue); });
             } else {
-              this.hls.trigger(Event.CUES_PARSED, { type: 'subtitles', cues: cues, track: 'subtitles'+frag.trackId });
+              let track = tracks[frag.trackId];
+              let trackId = track.default ? 'default' : 'subtitles' + frag.trackId;
+              this.hls.trigger(Event.CUES_PARSED, { type: 'subtitles', cues: cues, track: trackId });
             }
             hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, { success: true, frag: frag });
           },


### PR DESCRIPTION
### What does this Pull Request do?
Ensures parsed cues are associated with the same id used to create the internal TextTrack.

### Why is this Pull Request needed?
hls.js was passing along a trackId that was different than the one created internally for the subtitle track. This resulted in an additional track being added to the cc menu.

### Are there any points in the code the reviewer needs to double check?
No. 

### Are there any Pull Requests open in other repos which need to be merged with this?
No.

#### Addresses Issue(s):

JW7-4022

