### PR TITLE
Apply max silent frame duration to AAC

### DIFF
--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -10,7 +10,7 @@ import MP4 from '../remux/mp4-generator';
 import {ErrorTypes, ErrorDetails} from '../errors';
 
 // 10 seconds
-const MAX_SILENT_FRAME_DURATION = 10 * 60 * 1000;
+const MAX_SILENT_FRAME_DURATION = 10 * 1000;
 
 class MP4Remuxer {
   constructor(observer, config, typeSupported, vendor) {
@@ -521,7 +521,7 @@ class MP4Remuxer {
         if (contiguous && track.isAAC) {
           // log delta
           if (delta) {
-            if (delta > 0) {
+            if (delta > 0 && delta < MAX_SILENT_FRAME_DURATION) {
               numMissingFrames = Math.round((ptsnorm - nextAudioPts) / inputSampleDuration);
               logger.log(`${delta} ms hole between AAC samples detected,filling it`);
               if (numMissingFrames > 0) {


### PR DESCRIPTION
### What does this Pull Request do?
Applies max gap duration to AAC remuxing

### Why is this Pull Request needed?
This fix was previously applied only to mp4

### Are there any points in the code the reviewer needs to double check?
No code points; however, when seeking, the duration may change to a bad value (i.e. 21 hours). This is expected and while it is a bug it is out of the scope of this ticket. However, MSE should not fail with a source buffer too large exception.

### Are there any Pull Requests open in other repos which need to be merged with this?
Nope

#### Addresses Issue(s):

JW7-4300

