### PR TITLE
Don't use the bitrate test fragment to calculate nextLoadPos

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -503,13 +503,15 @@ class StreamController extends EventHandler {
         frag.loadCounter = 1;
       }
       frag.loadIdx = this.fragLoadIdx;
-      this.fragCurrent = frag;
-      this.startFragRequested = true;
-      if (!isNaN(frag.sn)) {
-        this.nextLoadPosition = frag.start + frag.duration;
-      }
       frag.autoLevel = hls.autoLevelEnabled;
       frag.bitrateTest = this.bitrateTest;
+
+      this.fragCurrent = frag;
+      this.startFragRequested = true;
+      // Don't update nextLoadPosition for fragments which are not buffered
+      if (!isNaN(frag.sn) && !frag.bitrateTest) {
+        this.nextLoadPosition = frag.start + frag.duration;
+      }
       hls.trigger(Event.FRAG_LOADING, {frag: frag});
       // lazy demuxer init, as this could take some time ... do it during frag loading
       if (!this.demuxer) {


### PR DESCRIPTION
### What does this Pull Request do?
Prevent advancing of `nextLoadPos` for frags which are downloaded to test bitrate

### Why is this Pull Request needed?
Bitrate test frags do not get demuxed and buffered; if, by loading these frags, we advance `nextLoadPos`, then we will potentially skip 1 segment's length of video at the start.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW7-4355

