### PR TITLE
Assume an initPTS of 90000 for VTT if we do not receive an initPTS 

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -361,7 +361,7 @@ class TimelineController extends EventHandler {
     }
   }
 
-  onFragParsingInitSegment(data) {
+  onFragParsingInitSegment() {
     // If we receive this event, we have not received an onInitPtsFound event. This happens when the video track has no samples (but has audio)
     // In order to have captions display, which requires an initPTS, we assume one of 90000
     if (typeof this.initPTS === 'undefined') {

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -35,7 +35,9 @@ class TimelineController extends EventHandler {
                 Event.MANIFEST_LOADED,
                 Event.FRAG_LOADED,
                 Event.LEVEL_SWITCHING,
-                Event.INIT_PTS_FOUND);
+                Event.INIT_PTS_FOUND,
+                Event.FRAG_PARSING_INIT_SEGMENT
+    );
 
     this.hls = hls;
     this.config = hls.config;
@@ -256,7 +258,7 @@ class TimelineController extends EventHandler {
           textTrack.mode = track.default ? 'showing' : 'hidden';
           this.textTracks.push(textTrack);
         });
-      } else if (!sameTracks) {
+      } else if (!sameTracks && this.tracks && this.tracks.length) {
         // Create a list of tracks for the provider to consume
         let tracksList = this.tracks.map((track) => {
           return {
@@ -356,6 +358,14 @@ class TimelineController extends EventHandler {
         var ccdatas = this.extractCea608Data(data.samples[i].bytes);
         this.cea608Parser.addData(data.samples[i].pts, ccdatas);
       }
+    }
+  }
+
+  onFragParsingInitSegment(data) {
+    // If we receive this event, we have not received an onInitPtsFound event. This happens when the video track has no samples (but has audio)
+    // In order to have captions display, which requires an initPTS, we assume one of 90000
+    if (typeof this.initPTS === 'undefined') {
+      this.onInitPtsFound({ initPTS: 90000 });
     }
   }
 


### PR DESCRIPTION
### What does this Pull Request do?
Triggers caption's local `initPtsFound` method with an assumed PTS value `onFragParsingInitSegment` - if we do not already have one.

Also puts a few safety checks around dispatching the non-native tracks event, preventing an empty array from being dispatched

### Why is this Pull Request needed?
Allows captions to render when a valid stream is playing but no initPTS is found (i.e. audio-only mp4)

### Are there any points in the code the reviewer needs to double check?
Is 90000 a safe assumption?

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):
JW7-3381


