### PR TITLE
Fix always true conditional preventing WAITING_INIT_PTS state

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -615,7 +615,7 @@ class AudioStreamController extends EventHandler {
         // If not we need to wait for it
         let initPTS = this.initPTS[cc];
         let initSegmentData = details.initSegment ? details.initSegment.data : [];
-        if (initSegmentData || initPTS !== undefined) {
+        if (details.initSegment || initPTS !== undefined) {
           this.pendingBuffering = true;
           logger.log(`Demuxing ${sn} of [${details.startSN} ,${details.endSN}],track ${trackId}`);
           // time Offset is accurate if level PTS is known, or if playlist is not sliding (not live)


### PR DESCRIPTION
### What does this Pull Request do?
Fixes a bug in a conditional statement that was always true

### Why is this Pull Request needed?
Not entering the WAITING_INIT_PTS state prevents audio/video from being synced, which prevents the stream from starting

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):
JW7-4431

https://github.com/video-dev/hls.js/pull/1098
