### PR TITLE
Always load from given start position when buffer cannot be read

### DIFF
--- a/src/helper/buffer-helper.js
+++ b/src/helper/buffer-helper.js
@@ -16,18 +16,21 @@ const BufferHelper = {
   },
 
   bufferInfo : function(media, pos,maxHoleDuration) {
+    // When the buffer can't be read load from the given position (buffer end determines load position)
+    const defaultBufferInfo = { len: 0, start: pos, end: pos, nextStart : undefined };
     if (media) {
       try {
-        var vbuffered = media.buffered, buffered = [], i;
-        for (i = 0; i < vbuffered.length; i++) {
+        const vbuffered = media.buffered;
+        const buffered = [];
+        for (let i = 0; i < vbuffered.length; i++) {
           buffered.push({start: vbuffered.start(i), end: vbuffered.end(i)});
         }
         return this.bufferedInfo(buffered, pos, maxHoleDuration);
       } catch(e) {
-        return {len: 0, start: 0, end: 0, nextStart : undefined} ;
+        return defaultBufferInfo;
       }
     } else {
-      return {len: 0, start: pos, end: pos, nextStart : undefined} ;
+      return defaultBufferInfo;
     }
   },
 


### PR DESCRIPTION
### What does this Pull Request do?
Always return `bufferInfo` with `start` and `end` set to the given `pos` in cases where the buffer can't be read. 

### Why is this Pull Request needed?
Sometimes the buffer can't be read, especially when re-attaching to the tag. Inability to read the buffer isn't a fatal error and Hlsjs works around such cases. However, we default to loading from position `0` (load pos is determined by buffer end) when this happens, causing streams to start from the beginning again. This is evident in midroll ads with a re-attach followed by an audio track switch.

Test stream: http://v.watch.cbc.ca/p//38e815a-00b553d24a9//CBC_DRAGONS_SEASON_11_S11E09-v2-11272128/CBC_DRAGONS_SEASON_11_S11E09-v2-11272128__desktop.m3u8?cbcott=st=1497541190~exp=1497627590~acl=/*~hmac=513981adb81dde9efd6d85a62295837a4f4dc727abd45b159761889e8502cf65

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW7-4446

