### PR TITLE
When tracks disabled, cues are added twice

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -9,10 +9,15 @@ import WebVTTParser from '../utils/webvtt-parser';
 import {logger} from '../utils/logger';
 
 function clearCurrentCues(track) {
-  if (track && track.cues) {
+  if (track) {
+    let trackMode = track.mode;
+    if (trackMode === 'disabled') {
+      track.mode = 'hidden';
+    }
     while (track.cues.length > 0) {
       track.removeCue(track.cues[0]);
     }
+    track.mode = trackMode;
   }
 }
 


### PR DESCRIPTION
### What does this Pull Request do?

When trying to clear cues, if the track mode is disabled, change mode to hidden before clearing

### Why is this Pull Request needed?

Cues cannot be cleared while the track mode is disabled

#### Addresses Issue(s):

JW7-4455

