### PR TITLE
Fix live stream restarting from beginning after ad

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -336,6 +336,7 @@ class StreamController extends EventHandler {
         if (media && media.readyState && media.duration > liveSyncPosition) {
           media.currentTime = liveSyncPosition;
         }
+        this.nextLoadPosition = liveSyncPosition;
     }
 
     // if end of buffer greater than live edge, don't load any fragment


### PR DESCRIPTION
### What does this Pull Request do?
Set nextLoadPosition to liveSyncPosition when the playhead is too far from the edge

### Why is this Pull Request needed?
Streams should start from the live edge after re-attaching

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

JW7-4485

