### PR TITLE
Reset textTracks on stop and when the first cue is received

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -77,10 +77,7 @@ class TimelineController extends EventHandler {
               } else {
                 self.textTrack1 = existingTrack1;
                 clearCurrentCues(self.textTrack1);
-
-                let event = new window.Event('addtrack');
-                event.track = self.textTrack1;
-                self.media.dispatchEvent(event);
+                self.textTrack1.inuse = true;
               }
             } else {
               // Create a list of a single track for the provider to consume
@@ -90,7 +87,7 @@ class TimelineController extends EventHandler {
                 'kind': 'captions',
                 'default': false
               };
-              self.hls.trigger(Event.NON_NATIVE_TEXT_TRACKS_FOUND, { tracks: [ self.textTrack1] });
+              self.hls.trigger(Event.NON_NATIVE_TEXT_TRACKS_FOUND, { tracks: [ self.textTrack1 ] });
             }
           }
 
@@ -111,10 +108,7 @@ class TimelineController extends EventHandler {
               } else {
                 self.textTrack2 = existingTrack2;
                 clearCurrentCues(self.textTrack2);
-
-                let event = new window.Event('addtrack');
-                event.track = self.textTrack2;
-                self.media.dispatchEvent(event);
+                self.textTrack2.inuse = true;
               }
             } else {
               // Create a list of a single track for the provider to consume
@@ -124,7 +118,7 @@ class TimelineController extends EventHandler {
                 'kind': 'captions',
                 'default': false
               };
-              self.hls.trigger(Event.NON_NATIVE_TEXT_TRACKS_FOUND, { tracks: [ self.textTrack2] });
+              self.hls.trigger(Event.NON_NATIVE_TEXT_TRACKS_FOUND, { tracks: [ self.textTrack2 ] });
             }
           }
 
@@ -213,6 +207,8 @@ class TimelineController extends EventHandler {
   onMediaDetaching() {
     clearCurrentCues(this.textTrack1);
     clearCurrentCues(this.textTrack2);
+    delete this.textTrack1;
+    delete this.textTrack2;
   }
 
   onManifestLoading()


### PR DESCRIPTION
### What does this Pull Request do?
- Set captions textTrack to inuse after receiving the first cue
- Delete tracks from the timeline controller when stop is called
### Why is this Pull Request needed?
- Reused captions tracks weren't being set to `inuse` when a cue is first received for playlist items after the first item.
- We clear cues when `stop()` is called, which disables text tracks and sets `inuse = false`. The timeline controller was still holding on to its local tracks, though, which meant that on play, the reused tracks were not being setup correctly.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/4080
#### Addresses Issue(s):
JW8-563

