### PR TITLE
Don’t add duplicate tracks, regardless of rendering method

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -248,34 +248,36 @@ class TimelineController extends EventHandler {
       const sameTracks = this.tracks && data.subtitles && this.tracks.length === data.subtitles.length;
       this.tracks = data.subtitles || [];
 
-      if (this.config.renderNatively) {
-        let inUseTracks = this.media ? this.media.textTracks : [];
+      if (!sameTracks) {
+        if (this.config.renderNatively) {
+          let inUseTracks = this.media ? this.media.textTracks : [];
 
-        this.tracks.forEach((track, index) => {
-          let textTrack;
-          if (index < inUseTracks.length) {
-            const inUseTrack = inUseTracks[index];
-            // Reuse tracks with the same label, but do not reuse 608/708 tracks
-            if (reuseVttTextTrack(inUseTrack, track)) {
-              textTrack = inUseTrack;
+          this.tracks.forEach((track, index) => {
+            let textTrack;
+            if (index < inUseTracks.length) {
+              const inUseTrack = inUseTracks[index];
+              // Reuse tracks with the same label, but do not reuse 608/708 tracks
+              if (reuseVttTextTrack(inUseTrack, track)) {
+                textTrack = inUseTrack;
+              }
             }
-          }
-          if (!textTrack) {
-            textTrack = this.createTextTrack('subtitles', track.name, track.lang);
-          }
-          textTrack.mode = track.default ? 'showing' : 'hidden';
-          this.textTracks.push(textTrack);
-        });
-      } else if (!sameTracks && this.tracks && this.tracks.length) {
-        // Create a list of tracks for the provider to consume
-        let tracksList = this.tracks.map((track) => {
-          return {
-            'label': track.name,
-            'kind': track.type.toLowerCase(),
-            'default': track.default
-          };
-        });
-        this.hls.trigger(Event.NON_NATIVE_TEXT_TRACKS_FOUND, { tracks: tracksList });
+            if (!textTrack) {
+              textTrack = this.createTextTrack('subtitles', track.name, track.lang);
+            }
+            textTrack.mode = track.default ? 'showing' : 'hidden';
+            this.textTracks.push(textTrack);
+          });
+        } else if (this.tracks && this.tracks.length) {
+          // Create a list of tracks for the provider to consume
+          let tracksList = this.tracks.map((track) => {
+            return {
+              'label': track.name,
+              'kind': track.type.toLowerCase(),
+              'default': track.default
+            };
+          });
+          this.hls.trigger(Event.NON_NATIVE_TEXT_TRACKS_FOUND, { tracks: tracksList });
+        }
       }
     }
 


### PR DESCRIPTION
### Description of the Changes
Duplicate subtitles tracks were being added after a pre-roll for browser-rendered textTracks. This ensures that we don't do that. 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
