### PR TITLE
Guard check cue removal 

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -18,7 +18,7 @@ function clearCurrentCues(track) {
     if (trackMode === 'disabled') {
       track.mode = 'hidden';
     }
-    while (track.cues.length > 0) {
+    while (track.cues && track.cues.length > 0) {
       track.removeCue(track.cues[0]);
     }
     track.mode = trackMode;


### PR DESCRIPTION
### Why is this Pull Request needed?
Slow browsers can run into race conditions around cue & track removal, causing exceptions.

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer/pull/2420

#### Addresses Issue(s):

JW8-465

