### PR TITLE
Adjust reload interval for onLevelLoaded event handler

### DIFF
--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -317,6 +317,7 @@ class LevelController extends EventHandler {
 
   onLevelLoaded(data) {
     const levelId = data.level;
+    const playbackRate = this.hls.media.playbackRate;
     // only process level loaded events matching with expected level
     if (levelId === this._level) {
       let curLevel = this._levels[levelId];
@@ -329,6 +330,7 @@ class LevelController extends EventHandler {
       if (newDetails.live) {
         let reloadInterval = 1000 * ( newDetails.averagetargetduration ? newDetails.averagetargetduration : newDetails.targetduration),
             curDetails     = curLevel.details;
+        reloadInterval /= playbackRate;
         if (curDetails && newDetails.endSN === curDetails.endSN) {
           // follow HLS Spec, If the client reloads a Playlist file and finds that it has not
           // changed then it MUST wait for a period of one-half the target

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -317,7 +317,6 @@ class LevelController extends EventHandler {
 
   onLevelLoaded(data) {
     const levelId = data.level;
-    const playbackRate = this.hls.media.playbackRate;
     // only process level loaded events matching with expected level
     if (levelId === this._level) {
       let curLevel = this._levels[levelId];
@@ -330,7 +329,6 @@ class LevelController extends EventHandler {
       if (newDetails.live) {
         let reloadInterval = 1000 * ( newDetails.averagetargetduration ? newDetails.averagetargetduration : newDetails.targetduration),
             curDetails     = curLevel.details;
-        reloadInterval /= playbackRate;
         if (curDetails && newDetails.endSN === curDetails.endSN) {
           // follow HLS Spec, If the client reloads a Playlist file and finds that it has not
           // changed then it MUST wait for a period of one-half the target

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -612,7 +612,7 @@ class StreamController extends EventHandler {
         media decode error, check this, to avoid seeking back to
         wrong position after a media decode error
       */
-      if(currentTime > video.playbackRate*this.lastCurrentTime) {
+      if(currentTime > this.lastCurrentTime) {
         this.lastCurrentTime = currentTime;
       }
       if (BufferHelper.isBuffered(video,currentTime)) {


### PR DESCRIPTION
### This PR will...
Adjust the reload interval for onLevelLoaded to better check if the stream is on the live edge

### Why is this Pull Request needed?
When the user has a playback of > 1, the stream will eventually catch up to the edge and stall. It will continue to buffer and catch up to the edge if the playback rate is left at > 1

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/4216

#### Addresses Issue(s):

JW8-586

