### PR TITLE
Trigger an error when a level is empty, add removeLevel API

### DIFF
--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -16,7 +16,8 @@ class LevelController extends EventHandler {
       Event.MANIFEST_LOADED,
       Event.LEVEL_LOADED,
       Event.FRAG_LOADED,
-      Event.ERROR);
+      Event.ERROR,
+      Event.LEVEL_REMOVED);
     this._manualLevel = -1;
     this.timer = null;
   }
@@ -372,6 +373,10 @@ class LevelController extends EventHandler {
     if (this._manualLevel === -1) {
       this.hls.nextAutoLevel = nextLevel;
     }
+  }
+
+  onLevelRemoved(data) {
+    this._levels = this.levels.filter((level, index) => index !== data.level);
   }
 }
 

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -188,7 +188,7 @@ class StreamController extends EventHandler {
     // if start level not parsed yet OR
     // if video not attached AND start fragment already requested OR start frag prefetch disable
     // exit loop, as we either need more info (level not parsed) or we need media to be attached to load new fragment
-    if ((this.levelLastLoaded === undefined) || (
+    if (this.levelLastLoaded === undefined || (
       !media && (this.startFragRequested || !config.startFragPrefetch))) {
       return;
     }

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -188,7 +188,7 @@ class StreamController extends EventHandler {
     // if start level not parsed yet OR
     // if video not attached AND start fragment already requested OR start frag prefetch disable
     // exit loop, as we either need more info (level not parsed) or we need media to be attached to load new fragment
-    if (this.levelLastLoaded === undefined || (
+    if ((this.levelLastLoaded === undefined) || (
       !media && (this.startFragRequested || !config.startFragPrefetch))) {
       return;
     }

--- a/src/errors.js
+++ b/src/errors.js
@@ -18,8 +18,8 @@ export const ErrorDetails = {
   MANIFEST_PARSING_ERROR: 'manifestParsingError',
   // Identifier for a manifest with only incompatible codecs error - data: { url : faulty URL, reason : error reason}
   MANIFEST_INCOMPATIBLE_CODECS_ERROR: 'manifestIncompatibleCodecsError',
-  //
-  MANIFEST_EMPTY_ERROR: 'manifestEmptyError',
+  // Identifier for a level which contains no fragments - data: { url: faulty URL, reason: error reason, level: index of the bad level }
+  LEVEL_EMPTY_ERROR: 'levelEmptyError',
   // Identifier for a level load error - data: { url : faulty URL, response : { code: error code, text: error text }}
   LEVEL_LOAD_ERROR: 'levelLoadError',
   // Identifier for a level load timeout - data: { url : faulty URL, response : { code: error code, text: error text }}

--- a/src/events.js
+++ b/src/events.js
@@ -45,7 +45,7 @@ export default {
   LEVEL_PTS_UPDATED: 'hlsLevelPtsUpdated',
   // fired to notify that audio track lists has been updated - data: { audioTracks : audioTracks }
   LEVEL_REMOVED: 'hlsLevelRemoved',
-  // fired when a level should no longer be used
+  // fired when a level should be removed
   AUDIO_TRACKS_UPDATED: 'hlsAudioTracksUpdated',
   // fired when an audio track switch occurs - data: { id : audio track id } // deprecated in favor AUDIO_TRACK_SWITCHING
   AUDIO_TRACK_SWITCH: 'hlsAudioTrackSwitch',

--- a/src/hls.js
+++ b/src/hls.js
@@ -195,6 +195,10 @@ export default class Hls {
     this.attachMedia(media);
   }
 
+  removeLevel(level) {
+    this.trigger(Event.LEVEL_REMOVED, { level });
+  }
+
   /** Return all quality levels **/
   get levels() {
     return this.levelController.levels;

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -562,7 +562,14 @@ class PlaylistLoader extends EventHandler {
               networkDetails
             });
           } else {
-            hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_EMPTY_ERROR, fatal: false, url: url, reason: 'no level found in manifest', context });
+            hls.trigger(Event.ERROR, {
+              type: ErrorTypes.NETWORK_ERROR,
+              details: ErrorDetails.LEVEL_EMPTY_ERROR,
+              fatal: false,
+              url: url,
+              reason: 'no fragments found in level',
+              level: context.level
+            });
           }
         }
       }


### PR DESCRIPTION
### Why is this Pull Request needed?
We want to detect empty levels and offer an API to remove them, so that clients can continue playing around bad streams

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/4251

#### Addresses Issue(s):

JW8-680

