### PR TITLE
Filter cues only when rendering natively

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -340,13 +340,13 @@ class TimelineController extends EventHandler {
         // Parse the WebVTT file contents.
         WebVTTParser.parse(payload, this.initPTS, vttCCs, frag.cc, function (cues) {
             const currentTrack = tracks[frag.trackId];
-            const newCues = cues.filter(cue => !currentTrack.cues.getCueById(cue.id));
 
             if (self.config.renderNatively) {
-              newCues.forEach(cue => { currentTrack.addCue(cue); });
+              cues.filter(cue => !currentTrack.cues.getCueById(cue.id))
+                  .forEach(cue => { currentTrack.addCue(cue); });
             } else {
               let trackId = currentTrack.default ? 'default' : 'subtitles' + frag.trackId;
-              hls.trigger(Event.CUES_PARSED, { type: 'subtitles', cues: newCues, track: trackId });
+              hls.trigger(Event.CUES_PARSED, { type: 'subtitles', cues: cues, track: trackId });
             }
             hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, { success: true, frag: frag });
           },


### PR DESCRIPTION
### What does this Pull Request do?
Filter cues in the timeline controller to avoid dupes only when rendering natively. The player has its own caching logic, so we don't need to filter the list before passing the array to the player to be consumed.
### Why is this Pull Request needed?
We were calling a 'hidden' cue method (`getCueById`) that only works for native textTracks, even when the player is handling rendering. This caused an error that meant no cues were added to the track and subtitles tracks weren't showing cues when selected.
### Are there any points in the code the reviewer needs to double check?
No
### Are there any Pull Requests open in other repos which need to be merged with this?
No
#### Addresses Issue(s):
JW8-475