### PR TITLE
Format position and frag start/end PTS to get visualQuality on first frag change

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -555,10 +555,10 @@ class StreamController extends EventHandler {
 
   getBufferedFrag(position) {
     return BinarySearch.search(this._bufferedFrags, function(frag) {
-      if (position && frag.startPTS) {
-        const startPTS = parseFloat(frag.startPTS).toFixed(3);
-        const endPTS = parseFloat(frag.endPTS).toFixed(3);
-        position = parseFloat(position).toFixed(3);
+      if (position && frag.startPTS && frag.endPTS) {
+        const startPTS = frag.startPTS.toFixed(3);
+        const endPTS = frag.endPTS.toFixed(3);
+        position = position.toFixed(3);
 
         if (position < startPTS) {
           return -1;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -554,20 +554,24 @@ class StreamController extends EventHandler {
   }
 
   getBufferedFrag(position) {
-    return BinarySearch.search(this._bufferedFrags, function(frag) {
-      if (position && frag.startPTS && frag.endPTS) {
-        const startPTS = frag.startPTS.toFixed(3);
-        const endPTS = frag.endPTS.toFixed(3);
-        position = position.toFixed(3);
+    // Position and frag PTS values have differing precision; truncate to 3 digits so that marginal differences do not
+    // cause unexpected results (e.g. we want 1.000000001 to equal 1.000)
+    const trunc = num => Math.round(num * 1000) / 1000;
+    const isDefined = num => (num !== void 0) && (num !== null);
 
-        if (position < startPTS) {
+    if (!isDefined(position)) {
+      return;
+    }
+
+    return BinarySearch.search(this._bufferedFrags, function(frag) {
+      if (isDefined(frag.startPTS) && isDefined(frag.endPTS)) {
+        if (position < trunc(frag.startPTS)) {
           return -1;
-        } else if (position > endPTS) {
+        } else if (position > trunc(frag.endPTS)) {
           return 1;
         }
       }
       return 0;
-
     });
   }
 

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -563,11 +563,12 @@ class StreamController extends EventHandler {
       return;
     }
 
+    const truncPos = trunc(position);
     return BinarySearch.search(this._bufferedFrags, function(frag) {
       if (isDefined(frag.startPTS) && isDefined(frag.endPTS)) {
-        if (position < trunc(frag.startPTS)) {
+        if (truncPos < trunc(frag.startPTS)) {
           return -1;
-        } else if (position > trunc(frag.endPTS)) {
+        } else if (truncPos > trunc(frag.endPTS)) {
           return 1;
         }
       }

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -555,10 +555,14 @@ class StreamController extends EventHandler {
 
   getBufferedFrag(position) {
     return BinarySearch.search(this._bufferedFrags, function(frag) {
-      if (position && frag) {
-        if (parseFloat(position.toFixed(3)) < parseFloat(frag.startPTS.toFixed(3))) {
+      if (position && frag.startPTS) {
+        const startPTS = parseFloat(frag.startPTS).toFixed(3);
+        const endPTS = parseFloat(frag.endPTS).toFixed(3);
+        position = parseFloat(position).toFixed(3);
+
+        if (position < startPTS) {
           return -1;
-        } else if (parseFloat(position.toFixed(3)) > parseFloat(frag.endPTS.toFixed(3))) {
+        } else if (position > endPTS) {
           return 1;
         }
       }

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -555,12 +555,15 @@ class StreamController extends EventHandler {
 
   getBufferedFrag(position) {
     return BinarySearch.search(this._bufferedFrags, function(frag) {
-      if (position < frag.startPTS) {
-        return -1;
-      } else if (position > frag.endPTS) {
-        return 1;
+      if (position && frag) {
+        if (parseFloat(position.toFixed(3)) < parseFloat(frag.startPTS.toFixed(3))) {
+          return -1;
+        } else if (parseFloat(position.toFixed(3)) > parseFloat(frag.endPTS.toFixed(3))) {
+          return 1;
+        }
       }
       return 0;
+
     });
   }
 


### PR DESCRIPTION
### What does this Pull Request do?

Uses toFixed to format position, frag.startPTS, and frag.endPTS variables in stream-controller to properly compare them and fire visualQuality event on the first frag changed event.

### Why is this Pull Request needed?

The onAdapation function that fires the visualQuality event doesn't get called on the first frag change. The comparison in the binary search function fails because of the precision of the position, startPTS and endPTS

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer/pull/2515
https://github.com/jwplayer/jwplayer-commercial/pull/4288

#### Addresses Issue(s):

JW8-823

