### PR TITLE
Determine 608 captions line and position values according to spec

### DIFF
--- a/src/utils/cues.js
+++ b/src/utils/cues.js
@@ -49,19 +49,21 @@ export function createCues(startTime, endTime, captionScreen) {
           indent++;
         }
 
-        // VTTCue.line get's flakey when using controls, so let's now include line 13&14
-        // also, drop line 1 since it's to close to the top
-        if (navigator.userAgent.match(/Firefox\//)){
+        // The row value specifies which of the fifteen screen rows should contain the caption text
+        // https://en.wikipedia.org/wiki/EIA-608#Control_commands
+        // Need to normalize this value to 1-15 since r is 0-based
+        cue.line = r + 1;
 
-          cue.line = r + 1;
+        // Assume that if there's the same amount of white space (indent) before and after cue.text,
+        // the text should be centered.
+        // Account for slight overflow by using a tolerance of 2 columns
+        if (Math.abs(32 - (cue.text.length + indent * 2)) > 2) {
+          // The column width is defined as 2.5% of the video width, because CEA-608 requires 32 columns of characters
+          // to be rendered on 80% of the video's width.
+          // https://dvcs.w3.org/hg/text-tracks/raw-file/default/608toVTT/608toVTT.html#positioning-in-cea-608
+          cue.align = 'left';
+          cue.position = Math.max(10, Math.min(90, 10 + 2.5 * indent));
         }
-        else{
-
-          cue.line = (r > 7 ? r - 2 : r + 1);
-        }
-        cue.align = 'left';
-        // Clamp the position between 0 and 100 - if out of these bounds, Firefox throws an exception and captions break
-        cue.position = Math.max(0, Math.min(100, 100 * (indent / 32) ));
         cues.push(cue);
       }
     }


### PR DESCRIPTION
### Description of the Changes
These changes address both horizontal and vertical positioning of 608 captions.

1. Set captions line value to the spec range (1-15). Since the row value (r) is 0-based, we need to add 1.
2. The W3C draft for [converting 608 Captions to WebVTT](https://dvcs.w3.org/hg/text-tracks/raw-file/default/608toVTT/608toVTT.html#positioning-in-cea-608) calls for 32 columns of text. Text should occupy 80% of the video's width, so there needs to be 10% tolerance on either side. Each 'column' should occupy 2.5% of screen real estate, which needs to be factored in when determining the left position for L-to-R captions.
3. I noticed a pattern for rendering when comparing captions output with Safari. Captions were always left-aligned, even when the same cue in Safari had `align: middle`. When there's the same amount of whitespace to the left and right of captions text, it's safe to assume that the text should be centered. The added tolerance accounts for an odd number of text/indent characters.

Note: when neither value is set, `cue.position` defaults to `'auto'`  and `cue.align` defaults to `'center'` or `'middle'` depending on browser.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
