### PR TITLE
Set correct default values for cues

### DIFF
--- a/src/utils/vttcue.js
+++ b/src/utils/vttcue.js
@@ -100,11 +100,11 @@ export default (function() {
     var _region = null;
     var _vertical = '';
     var _snapToLines = true;
-    var _line = 'auto';
+    var _line = autoKeyword;
     var _lineAlign = 'start';
-    var _position = 50;
-    var _size = 50;
-    var _align = 'middle';
+    var _position = autoKeyword;
+    var _size = 100;
+    var _align = 'center';
 
     Object.defineProperty(cue, 'id', extend({}, baseObj, {
       get: function () {


### PR DESCRIPTION
### What does this Pull Request do?
Set the correct defaults for cues. 
### Why is this Pull Request needed?
In IE/Edge, where the `VTTCue` interface is polyfilled, cues were being created with the following defaults:
```
position: 50,
size: 50
```
This caused incorrect positioning of 608 captions that should be centered on the screen. The default value for these properties in browsers where the VTTCue interface exists is:
```
position: 'auto',
size: 100
```

Additionally, browsers expect the `align` value to be `'center'`  (except Safari, where it is `'middle'`), which is what is in the [WebVTT spec](https://www.w3.org/TR/webvtt1/#webvtt-cue-center-alignment). `VTTCue` isn't polyfilled in Safari anyway, so it's unaffected by this change.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer/pull/2522
#### Addresses Issue(s):
JW8-205

