### PR TITLE
Revert default align value. alignSetting expects it to be 'middle'

### DIFF
--- a/src/utils/vttcue.js
+++ b/src/utils/vttcue.js
@@ -104,7 +104,7 @@ export default (function() {
     var _lineAlign = 'start';
     var _position = autoKeyword;
     var _size = 100;
-    var _align = 'center';
+    var _align = 'middle';
 
     Object.defineProperty(cue, 'id', extend({}, baseObj, {
       get: function () {


### PR DESCRIPTION
### What does this Pull Request do?
Revert the default align value since alignSetting expects it to be 'middle'.
### Why is this Pull Request needed?
Changing align to middle caused exceptions when parsing captions.
### Are there any points in the code the reviewer needs to double check?
No.
### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer/pull/2523
#### Addresses Issue(s):
JW8-205

