### PR TITLE
Reset the subtitle tracks in the timeline controller when calling stop

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -45,7 +45,8 @@ class TimelineController extends EventHandler {
                 Event.FRAG_LOADED,
                 Event.LEVEL_SWITCHING,
                 Event.INIT_PTS_FOUND,
-                Event.FRAG_PARSING_INIT_SEGMENT
+                Event.FRAG_PARSING_INIT_SEGMENT,
+                Event.SUBTITLE_TRACKS_CLEARED
     );
 
     this.hls = hls;
@@ -361,6 +362,10 @@ class TimelineController extends EventHandler {
         this.hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, { success: false, frag: frag });
       }
     }
+  }
+
+  onSubtitleTracksCleared() {
+    this.tracks = [];
   }
 
   onFragParsingUserdata(data) {

--- a/src/events.js
+++ b/src/events.js
@@ -59,6 +59,8 @@ export default {
   AUDIO_TRACK_LOADED: 'hlsAudioTrackLoaded',
   // fired to notify that subtitle track lists has been updated - data: { subtitleTracks : subtitleTracks }
   SUBTITLE_TRACKS_UPDATED: 'hlsSubtitleTracksUpdated',
+  // fired to notify that subtitle tracks were cleared as a result of stopping the media
+  SUBTITLE_TRACKS_CLEARED: 'hlsSubtitleTracksCleared',
   // fired when an subtitle track switch occurs - data: { id : subtitle track id }
   SUBTITLE_TRACK_SWITCH: 'hlsSubtitleTrackSwitch',
   // fired when a subtitle track loading starts - data: { url : subtitle track URL, id : subtitle track id }


### PR DESCRIPTION
### What does this Pull Request do?
Clears the timeline controller's `tracks` array when `clearTracks()` is called.
### Why is this Pull Request needed?
`stop` is called when replaying media, which clears the tracks in the provider. Since the provider isn't destroyed when replaying media, the timeline controller had a reference to the old tracks, even though the manifest gets reloaded. This was an optimization to avoid reprocessing already parsed subtitle tracks when resuming playback after an ad, but it caused a side effect when replaying the stream.
### Are there any points in the code the reviewer needs to double check?
No
### Are there any Pull Requests open in other repos which need to be merged with this?
No
#### Addresses Issue(s):
JW8-917

