### PR TITLE
Avoid recalculating level cap when media has no height or width

### DIFF
--- a/src/controller/cap-level-controller.js
+++ b/src/controller/cap-level-controller.js
@@ -48,7 +48,7 @@ class CapLevelController extends EventHandler {
   }
 
   detectPlayerSize() {
-    if (this.media) {
+    if (this.media && this.mediaHeight > 0 && this.mediaWidth > 0) {
       let levelsLength = this.levels ? this.levels.length : 0;
       if (levelsLength) {
         const hls = this.hls;


### PR DESCRIPTION
### Why is this Pull Request needed?
When Hlsjs is background loading, the media size is 0

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?


#### Addresses Issue(s):
JW8-31

