### PR TITLE
[do not merge] Exclude localTime of 0 from cue offset calculation

### DIFF
--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -65,7 +65,7 @@ const WebVTTParser = {
         let vttLines = utf8ArrayToStr(new Uint8Array(vttByteArray)).trim().replace(re, '\n').split('\n');
         let cueTime = '00:00.000';
         let mpegTs = 0;
-        let localTime = undefined;
+        let localTime;
         let presentationTime = 0;
         let cues = [];
         let parsingError;

--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -65,7 +65,7 @@ const WebVTTParser = {
         let vttLines = utf8ArrayToStr(new Uint8Array(vttByteArray)).trim().replace(re, '\n').split('\n');
         let cueTime = '00:00.000';
         let mpegTs = 0;
-        let localTime = 0;
+        let localTime = undefined;
         let presentationTime = 0;
         let cues = [];
         let parsingError;
@@ -82,9 +82,9 @@ const WebVTTParser = {
 
             // Update offsets for new discontinuities
             if (currCC && currCC.new) {
-                if (localTime !== undefined) {
+                if (localTime) {
                     // When local time is provided, offset = discontinuity start time - local time
-                    cueOffset = vttCCs.ccOffset = currCC.start;
+                    cueOffset = vttCCs.ccOffset = currCC.start - localTime;
                 } else {
                     calculateOffset(vttCCs, cc, presentationTime);
                 }


### PR DESCRIPTION
### Why is this Pull Request needed?
To prevent an offset of 0 from desynchronizing cue time, especially after an SSAI break (where some publishers will not update the new localTime)

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

