### PR TITLE
Support streams that have multiple levels of audio

### DIFF
--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -84,7 +84,7 @@ class BufferController extends EventHandler {
 
   onManifestParsed(data) {
     let audioExpected = data.audio,
-        videoExpected = data.video || (data.levels.length && data.audio),
+        videoExpected = data.video || (data.levels.length && data.altAudio),
         sourceBufferNb = 0;
     // in case of alt audio 2 BUFFER_CODECS events will be triggered, one per stream controller
     // sourcebuffers will be created all at once when the expected nb of tracks will be reached

--- a/src/controller/cap-level-controller.js
+++ b/src/controller/cap-level-controller.js
@@ -37,7 +37,8 @@ class CapLevelController extends EventHandler {
   onManifestParsed(data) {
     const hls = this.hls;
     this.restrictedLevels = [];
-    if (hls.config.capLevelToPlayerSize) {
+    // Only fire getMaxLevel or detectPlayerSize if video is expected in the manifest
+    if (hls.config.capLevelToPlayerSize && (data.video || (data.levels.length && data.altAudio))) {
       this.autoLevelCapping = Number.POSITIVE_INFINITY;
       this.levels = data.levels;
       hls.firstLevel = this.getMaxLevel(data.firstLevel);

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -134,7 +134,7 @@ export default class LevelController extends EventHandler {
         stats     : data.stats,
         audio     : audioCodecFound,
         video     : videoCodecFound,
-        altAudio  : audioTracks.length > 0
+        altAudio  : audioTracks.length > 0 && videoCodecFound
       });
     } else {
       this.hls.trigger(Event.ERROR, {


### PR DESCRIPTION
### What does this Pull Request do?

Change the altAudio property to be true only if video was found.

### Why is this Pull Request needed?

The videoExpected property gets set to true because levels are detected when the manifest is parsed, but the levels are for audio tracks, not video.

#### Addresses Issue(s):

JW8-1159

