### PR TITLE
Add getter for HLS bandwidth estimate

### DIFF
--- a/src/hls.js
+++ b/src/hls.js
@@ -243,6 +243,12 @@ export default class Hls {
     return Math.max(this.levelController.firstLevel, this.minAutoLevel);
   }
 
+  /** Return Estimated Bandwidth
+   **/
+  get bandwidthEstimate() {
+    return this.abrController._bwEstimator.getEstimate();
+  }
+
   /** set first level (index of first level referenced in manifest)
   **/
   set firstLevel(newLevel) {


### PR DESCRIPTION
### What does this Pull Request do?

Exposes the estimated bandwidth Hlsjs can sustain through a getter in hls.js.

### Why is this Pull Request needed?

We need to be able to retrieve the bandwidth and save it so we can use it to start up videos at a better quality.

#### Addresses Issue(s):

JW8-1241

