### PR TITLE
Return NaN if bwEstimator doesn't exist on the abrController

### DIFF
--- a/src/hls.js
+++ b/src/hls.js
@@ -246,7 +246,8 @@ export default class Hls {
   /** Return Estimated Bandwidth
    **/
   get bandwidthEstimate() {
-    return this.abrController._bwEstimator.getEstimate();
+    const bwEstimator = this.abrController._bwEstimator;
+    return bwEstimator ? bwEstimator.getEstimate() : NaN;
   }
 
   /** set first level (index of first level referenced in manifest)


### PR DESCRIPTION
### What does this Pull Request do?

Return NaN if the _bwEstimator property doesnt exist  on the abrController object.

### Why is this Pull Request needed?

_bwEstimator can return undefined so when we try to call the getEstimate() function from it, it will toss an error if thats the case.

#### Addresses Issue(s):

JW8-1241
