### PR TITLE
Re-add captions parsing accidentally removed during 0.9.1 merge 

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -246,17 +246,17 @@ class TimelineController extends EventHandler {
     }
 
     if (this.config.enableCEA708Captions && data.captions) {
-      data.captions.forEach(function (captionsTrack) {
+      data.captions.forEach(captionsTrack => {
         let instreamIdMatch = /(?:CC|SERVICE)([1-2])/.exec(captionsTrack.instreamId);
 
         if (!instreamIdMatch)
           return;
 
-        let index = instreamIdMatch[1];
-        this.captionsProperties[index].name = captionsTrack.name;
+        let trackName = `textTrack${instreamIdMatch[1]}`;
+        this.captionsProperties[trackName].label = captionsTrack.name;
 
         if (captionsTrack.lang) { // optional attribute
-          this.captionsProperties[index].languageCode = captionsTrack.lang;
+          this.captionsProperties[trackName].languageCode = captionsTrack.lang;
         }
       });
     }

--- a/src/loader/m3u8-parser.js
+++ b/src/loader/m3u8-parser.js
@@ -114,6 +114,7 @@ export default class M3U8Parser {
       const attrs = new AttrList(result[1]);
       if (attrs.TYPE === type) {
         media.groupId = attrs['GROUP-ID'];
+        media.instreamId = attrs['INSTREAM-ID'];
         media.name = attrs.NAME;
         media.type = type;
         media.default = (attrs.DEFAULT === 'YES');

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -303,6 +303,7 @@ class PlaylistLoader extends EventHandler {
 
     let audioTracks = M3U8Parser.parseMasterPlaylistMedia(string, url, 'AUDIO', audioGroups);
     let subtitles = M3U8Parser.parseMasterPlaylistMedia(string, url, 'SUBTITLES');
+    let captions = M3U8Parser.parseMasterPlaylistMedia(string, url, 'CLOSED-CAPTIONS');
 
     if (audioTracks.length) {
       // check if we have found an audio track embedded in main playlist (audio track without URI attribute)
@@ -329,6 +330,7 @@ class PlaylistLoader extends EventHandler {
       levels,
       audioTracks,
       subtitles,
+      captions,
       url,
       stats,
       networkDetails


### PR DESCRIPTION
### Why is this Pull Request needed?
So that captions names signaled in the manifest are designated as the label of the captions track

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
JW8-1442