### PR TITLE
Remove premature set of stallReported to true

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1397,7 +1397,6 @@ class StreamController extends TaskLoop {
         // Allow some slack time to for small stalls to resolve themselves
         if (!this.stalled) {
           this.stalled = tnow;
-          this.stallReported = true;
           return;
         }
 

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -57,6 +57,7 @@ class StreamController extends TaskLoop {
     this.config = hls.config;
     this.audioCodecSwap = false;
     this._state = State.STOPPED;
+    this.stallReported = false;
   }
 
   onHandlerDestroying () {

--- a/tests/unit/controller/check-buffer.js
+++ b/tests/unit/controller/check-buffer.js
@@ -50,6 +50,7 @@ describe('checkBuffer', function () {
   describe('_reportStall', function () {
     it('should report a stall with the current buffer length if it has not already been reported', function () {
       streamController._reportStall(42);
+      assert.ok(streamController.stallReported);
       assert(triggerSpy.calledWith(Event.ERROR, {
         type: ErrorTypes.MEDIA_ERROR,
         details: ErrorDetails.BUFFER_STALLED_ERROR,
@@ -192,12 +193,12 @@ describe('checkBuffer', function () {
       setExpectedPlaying();
       streamController._checkBuffer();
 
-      // The first _checkBuffer call made while stalling just sets stall flags
+      // The first _checkBuffer call made while stalling just sets the stall time
       assert.equal(typeof streamController.stalled, 'number');
-      assert(streamController.stallReported);
+      assert.equal(streamController.stallReported, false);
 
       streamController._checkBuffer();
-      assert(fixStallStub.calledOnce);
+      assert.ok(fixStallStub.calledOnce);
     });
 
     it('should reset stall flags when no longer stalling', function () {


### PR DESCRIPTION
### Why is this Pull Request needed?
So that we trigger `bufferStall` errors

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
JW8-1448