### PR TITLE
Prevent "bufferStalledError" before playback has begun and when paused

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1380,7 +1380,8 @@ class StreamController extends TaskLoop {
     } else if (this.immediateSwitch) {
       this.immediateLevelSwitchEnd();
     } else {
-      const expectedPlaying = !((media.paused && media.readyState > 1) || // not playing when media is paused and sufficiently buffered
+      const expectedPlaying = !(media.paused || // not playing when media is paused
+        media.readyState < 2 || // not playing when insufficiently buffered
         media.ended || // not playing when media is ended
         media.buffered.length === 0); // not playing if nothing buffered
       const tnow = performance.now();


### PR DESCRIPTION
### This PR will...

Prevent "bufferStalledError" before playback has begun and when paused.

### Why is this Pull Request needed?

`expectedPlaying` evaluates as `true` when `video.paused` and `media.readyState` is less than `2`. This results in "bufferStalledError" events firing while media is being preloaded.

This change would also prevent "bufferStalledError" events from firing after playback has been started and paused. I don't know if that's a problem since `_tryFixBufferStall` could be attempted on the first tick after playback has resumed, and a stall while paused has no adverse impact on playback.
