### PR TITLE
Guard against using tracks automatically added by browsers 

### DIFF
--- a/src/controller/subtitle-track-controller.js
+++ b/src/controller/subtitle-track-controller.js
@@ -9,7 +9,9 @@ import { logger } from '../utils/logger';
 function filterSubtitleTracks (textTrackList) {
   let tracks = [];
   for (let i = 0; i < textTrackList.length; i++) {
-    if (textTrackList[i].kind === 'subtitles')
+    const track = textTrackList[i];
+    // Edge adds a track without a label; we don't want to use it
+    if (track.kind === 'subtitles' && track.label)
       tracks.push(textTrackList[i]);
   }
   return tracks;
@@ -35,7 +37,7 @@ class SubtitleTrackController extends EventHandler {
 
   _onTextTracksChanged () {
     // Media is undefined when switching streams via loadSource()
-    if (!this.media)
+    if (!this.media || !this.hls.config.renderNatively)
       return;
 
     let trackId = -1;
@@ -217,8 +219,8 @@ class SubtitleTrackController extends EventHandler {
    * @private
    */
   _toggleTrackModes (newId) {
-    const { media, subtitleDisplay, trackId } = this;
-    if (!media)
+    const { media, hls, subtitleDisplay, trackId } = this;
+    if (!media || !hls.renderNatively)
       return;
 
     const textTracks = filterSubtitleTracks(media.textTracks);

--- a/src/controller/subtitle-track-controller.js
+++ b/src/controller/subtitle-track-controller.js
@@ -220,7 +220,7 @@ class SubtitleTrackController extends EventHandler {
    */
   _toggleTrackModes (newId) {
     const { media, hls, subtitleDisplay, trackId } = this;
-    if (!media || !hls.renderNatively)
+    if (!media || !hls.config.renderNatively)
       return;
 
     const textTracks = filterSubtitleTracks(media.textTracks);

--- a/tests/unit/controller/subtitle-track-controller.js
+++ b/tests/unit/controller/subtitle-track-controller.js
@@ -9,7 +9,9 @@ describe('SubtitleTrackController', () => {
   let videoElement;
 
   beforeEach(() => {
-    const hls = new Hls();
+    const hls = new Hls({
+      renderNatively: true
+    });
 
     videoElement = document.createElement('video');
     subtitleTrackController = new SubtitleTrackController(hls);


### PR DESCRIPTION
### Why is this Pull Request needed?
So that when Edge automatically adds a track, Hls.js does not activate (and use it); this prevents two sets of captions (native and nonnative) from being displayed at once

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
JW8-1451