### PR TITLE
Prevent excessive bufferStall errors by only triggering when attempting to fix a stall JW8-1481

### DIFF
--- a/dist/hls.js
+++ b/dist/hls.js
@@ -9405,8 +9405,7 @@ var stream_controller_StreamController = function (_TaskLoop) {
     } else if (this.immediateSwitch) {
       this.immediateLevelSwitchEnd();
     } else {
-      var expectedPlaying = !(media.paused || // not playing when media is paused
-      media.readyState < 2 || // not playing when insufficiently buffered
+      var expectedPlaying = !(media.paused && media.readyState > 1 || // not playing when media is paused and sufficiently buffered
       media.ended || // not playing when media is ended
       media.buffered.length === 0); // not playing if nothing buffered
       var tnow = performance.now();

--- a/dist/hls.js
+++ b/dist/hls.js
@@ -9488,16 +9488,15 @@ var stream_controller_StreamController = function (_TaskLoop) {
     var currentTime = media.currentTime;
     var jumpThreshold = 0.5; // tolerance needed as some browsers stalls playback before reaching buffered range end
 
+    this._reportStall(bufferInfo.len);
     var partial = this.fragmentTracker.getPartialFragment(currentTime);
     if (partial) {
-      this._reportStall(bufferInfo.len);
       // Try to skip over the buffer hole caused by a partial fragment
       // This method isn't limited by the size of the gap between buffered ranges
       this._trySkipBufferHole(partial);
     }
 
     if (bufferInfo.len > jumpThreshold && stalledDuration > config.highBufferWatchdogPeriod * 1000) {
-      this._reportStall(bufferInfo.len);
       // Try to nudge currentTime over a buffer hole if we've been stalling for the configured amount of seconds
       // We only try to jump the hole if it's under the configured size
       // Reset stalled so to rearm watchdog timer

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1397,13 +1397,17 @@ class StreamController extends TaskLoop {
       } else if (expectedPlaying) {
         // The playhead isn't moving but it should be
         // Allow some slack time to for small stalls to resolve themselves
+        const stalledDuration = tnow - this.stalled;
+        console.log(tnow)
+        const bufferInfo = BufferHelper.bufferInfo(media, currentTime, config.maxBufferHole);
         if (!this.stalled) {
           this.stalled = tnow;
           return;
+        } else if (stalledDuration >= 1000) {
+          // Report stalling after trying to fix
+          this._reportStall(bufferInfo.len);
         }
 
-        const bufferInfo = BufferHelper.bufferInfo(media, currentTime, config.maxBufferHole);
-        const stalledDuration = tnow - this.stalled;
         this._tryFixBufferStall(bufferInfo, stalledDuration);
       }
     }
@@ -1472,10 +1476,6 @@ class StreamController extends TaskLoop {
       // Reset stalled so to rearm watchdog timer
       this.stalled = null;
       this._tryNudgeBuffer();
-    }
-
-    if (stalledDuration > 1000) {
-      this._reportStall(bufferInfo.len);
     }
   }
 

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1459,15 +1459,16 @@ class StreamController extends TaskLoop {
     const currentTime = media.currentTime;
     const jumpThreshold = 0.5; // tolerance needed as some browsers stalls playback before reaching buffered range end
 
-    this._reportStall(bufferInfo.len);
     const partial = this.fragmentTracker.getPartialFragment(currentTime);
     if (partial) {
+      this._reportStall(bufferInfo.len);
       // Try to skip over the buffer hole caused by a partial fragment
       // This method isn't limited by the size of the gap between buffered ranges
       this._trySkipBufferHole(partial);
     }
 
     if (bufferInfo.len > jumpThreshold && stalledDuration > config.highBufferWatchdogPeriod * 1000) {
+      this._reportStall(bufferInfo.len);
       // Try to nudge currentTime over a buffer hole if we've been stalling for the configured amount of seconds
       // We only try to jump the hole if it's under the configured size
       // Reset stalled so to rearm watchdog timer

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1461,19 +1461,21 @@ class StreamController extends TaskLoop {
 
     const partial = this.fragmentTracker.getPartialFragment(currentTime);
     if (partial) {
-      this._reportStall(bufferInfo.len);
       // Try to skip over the buffer hole caused by a partial fragment
       // This method isn't limited by the size of the gap between buffered ranges
       this._trySkipBufferHole(partial);
     }
 
     if (bufferInfo.len > jumpThreshold && stalledDuration > config.highBufferWatchdogPeriod * 1000) {
-      this._reportStall(bufferInfo.len);
       // Try to nudge currentTime over a buffer hole if we've been stalling for the configured amount of seconds
       // We only try to jump the hole if it's under the configured size
       // Reset stalled so to rearm watchdog timer
       this.stalled = null;
       this._tryNudgeBuffer();
+    }
+
+    if (stalledDuration > 1000) {
+      this._reportStall(bufferInfo.len);
     }
   }
 

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1398,7 +1398,6 @@ class StreamController extends TaskLoop {
         // The playhead isn't moving but it should be
         // Allow some slack time to for small stalls to resolve themselves
         const stalledDuration = tnow - this.stalled;
-        console.log(tnow)
         const bufferInfo = BufferHelper.bufferInfo(media, currentTime, config.maxBufferHole);
         if (!this.stalled) {
           this.stalled = tnow;

--- a/tests/unit/controller/check-buffer.js
+++ b/tests/unit/controller/check-buffer.js
@@ -87,7 +87,7 @@ describe('checkBuffer', function () {
       const nudgeStub = sinon.stub(streamController, '_tryNudgeBuffer');
       streamController._tryFixBufferStall(mockBufferInfo, mockStallDuration);
       assert(nudgeStub.notCalled);
-      assert(reportStallSpy.calledOnce);
+      assert(reportStallSpy.notCalled);
     });
 
     it('should not nudge when too far from the buffer end', function () {
@@ -96,7 +96,7 @@ describe('checkBuffer', function () {
       const nudgeStub = sinon.stub(streamController, '_tryNudgeBuffer');
       streamController._tryFixBufferStall(mockBufferInfo, mockStallDuration);
       assert(nudgeStub.notCalled);
-      assert(reportStallSpy.calledOnce);
+      assert(reportStallSpy.notCalled);
     });
 
     it('should try to jump partial fragments when detected', function () {
@@ -112,7 +112,7 @@ describe('checkBuffer', function () {
       const skipHoleStub = sinon.stub(streamController, '_trySkipBufferHole');
       streamController._tryFixBufferStall({ len: 0 });
       assert(skipHoleStub.notCalled);
-      assert(reportStallSpy.calledOnce);
+      assert(reportStallSpy.notCalled);
     });
   });
 


### PR DESCRIPTION
### Why is this Pull Request needed?
So that we don't trigger buffer stall errors excessively (i.e. when we seek backwards but only stall for a very short period of time)

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
JW8-1481