### PR TITLE
Remove readyState check from expectedPlaying

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1381,7 +1381,6 @@ class StreamController extends TaskLoop {
       this.immediateLevelSwitchEnd();
     } else {
       const expectedPlaying = !(media.paused || // not playing when media is paused
-        media.readyState < 2 || // not playing when insufficiently buffered
         media.ended || // not playing when media is ended
         media.buffered.length === 0); // not playing if nothing buffered
       const tnow = performance.now();


### PR DESCRIPTION
### Why is this Pull Request needed?
So that streams seek past gaps at the start of a stream

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
JW8-1484
