### PR TITLE
Resovle partial fragment loop loading

### DIFF
--- a/src/controller/abr-controller.js
+++ b/src/controller/abr-controller.js
@@ -37,23 +37,24 @@ class AbrController extends EventHandler {
         this.fragCurrent = frag;
         this.timer = setInterval(this.onCheck, 100);
 
-      // lazy init of bw Estimator, rationale is that we use different params for Live/VoD
-      // so we need to wait for stream manifest / playlist type to instantiate it.
-      if (!this._bwEstimator) {
-        let hls = this.hls,
-          level = data.frag.level,
-          isLive = hls.levels[level].details.live,
-          config = hls.config,
-          ewmaFast, ewmaSlow;
+        // lazy init of bw Estimator, rationale is that we use different params for Live/VoD
+        // so we need to wait for stream manifest / playlist type to instantiate it.
+        if (!this._bwEstimator) {
+          let hls = this.hls,
+            level = data.frag.level,
+            isLive = hls.levels[level].details.live,
+            config = hls.config,
+            ewmaFast, ewmaSlow;
 
-        if (isLive) {
-          ewmaFast = config.abrEwmaFastLive;
-          ewmaSlow = config.abrEwmaSlowLive;
-        } else {
-          ewmaFast = config.abrEwmaFastVoD;
-          ewmaSlow = config.abrEwmaSlowVoD;
+          if (isLive) {
+            ewmaFast = config.abrEwmaFastLive;
+            ewmaSlow = config.abrEwmaSlowLive;
+          } else {
+            ewmaFast = config.abrEwmaFastVoD;
+            ewmaSlow = config.abrEwmaSlowVoD;
+          }
+          this._bwEstimator = new EwmaBandWidthEstimator(hls, ewmaSlow, ewmaFast, config.abrEwmaDefaultEstimate);
         }
-        this._bwEstimator = new EwmaBandWidthEstimator(hls, ewmaSlow, ewmaFast, config.abrEwmaDefaultEstimate);
       }
     }
   }

--- a/src/controller/abr-controller.js
+++ b/src/controller/abr-controller.js
@@ -33,7 +33,8 @@ class AbrController extends EventHandler {
   onFragLoading (data) {
     let frag = data.frag;
     if (frag.type === 'main') {
-      if (!this.timer)
+      if (!this.timer) {
+        this.fragCurrent = frag;
         this.timer = setInterval(this.onCheck, 100);
 
       // lazy init of bw Estimator, rationale is that we use different params for Live/VoD
@@ -54,7 +55,6 @@ class AbrController extends EventHandler {
         }
         this._bwEstimator = new EwmaBandWidthEstimator(hls, ewmaSlow, ewmaFast, config.abrEwmaDefaultEstimate);
       }
-      this.fragCurrent = frag;
     }
   }
 
@@ -64,7 +64,11 @@ class AbrController extends EventHandler {
       we compute expected time of arrival of the complete fragment.
       we compare it to expected time of buffer starvation
     */
-    let hls = this.hls, v = hls.media, frag = this.fragCurrent, loader = frag.loader, minAutoLevel = hls.minAutoLevel;
+    const hls = this.hls;
+    const v = hls.media;
+    const frag = this.fragCurrent;
+    const minAutoLevel = hls.minAutoLevel;
+    const loader = frag.loader;
 
     // if loader has been destroyed or loading has been aborted, stop timer and return
     if (!loader || (loader.stats && loader.stats.aborted)) {

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -520,7 +520,7 @@ class StreamController extends TaskLoop {
         this.nextLoadPosition = frag.start + frag.duration;
 
       // Allow backtracked fragments to load
-      if (frag.backtracked || fragState === FragmentState.NOT_LOADED) {
+      if (frag.backtracked || fragState === FragmentState.NOT_LOADED || fragState === FragmentState.PARTIAL) {
         frag.autoLevel = this.hls.autoLevelEnabled;
         frag.bitrateTest = this.bitrateTest;
 
@@ -1115,9 +1115,9 @@ class StreamController extends TaskLoop {
           if (!frag.backtracked) {
             const levelDetails = level.details;
             if (levelDetails && frag.sn === levelDetails.startSN) {
-              logger.warn('missing video frame(s) on first frag, appending with gap');
+              logger.warn('missing video frame(s) on first frag, appending with gap', frag.sn);
             } else {
-              logger.warn('missing video frame(s), backtracking fragment');
+              logger.warn('missing video frame(s), backtracking fragment', frag.sn);
               // Return back to the IDLE state without appending to buffer
               // Causes findFragments to backtrack a segment and find the keyframe
               // Audio fragments arriving before video sets the nextLoadPosition, causing _findFragments to skip the backtracked fragment
@@ -1130,7 +1130,7 @@ class StreamController extends TaskLoop {
               return;
             }
           } else {
-            logger.warn('Already backtracked on this fragment, appending with the gap');
+            logger.warn('Already backtracked on this fragment, appending with the gap', frag.sn);
           }
         } else {
           // Only reset the backtracked flag if we've loaded the frag without any dropped frames


### PR DESCRIPTION
### This PR will...
- Load partial frags
- Set currentFrag before arming abr check timer

### Why is this Pull Request needed?
- So that partial frags which have been loaded once are allowed to load again. This can happen when seeking backwards into a region which requires that fragment to be loaded again. Without this change, that fragment continuously loads until `checkBuffer()` intervenes by nudging `currentTime.

- So that slow code execution does not cause `onCheck` to fire before `this.currentFrag` has been set.

### Are there any points in the code the reviewer needs to double check?
Awaiting review from upstream

### Resolves issues:
JW8-1514