### PR TITLE
Set fragPlaying to null on manifest parsed

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -809,6 +809,7 @@ class StreamController extends TaskLoop {
 
     this.levels = data.levels;
     this.startFragRequested = false;
+    this.fragPlaying = null;
     let config = this.config;
     if (config.autoStartLoad || this.forceStartLoad)
       this.hls.startLoad(config.startPosition);


### PR DESCRIPTION
### This PR will...

Set frag playing to null on manifest parsed.

### Why is this Pull Request needed?

The qualities submenu gets recreated on HLS for android chrome because we have to prime the video for playback again once a preroll has ended. This erases the quality label next to auto and it wont get set again until the next quality change.

On the second load, "this.fragPlaying" is equal to the current fragment from the first load so the "level_switched" event wont fire. If we set "this.fragPlaying" to null on "onManifestParsed", we can trigger the level_switched event which will eventually trigger visualQuality to set the quality label in the submenu again.

```javascript
 if (!this.fragPlaying || this.fragPlaying.level !== fragPlayingLevel)
            this.hls.trigger(Event.LEVEL_SWITCHED, { level: fragPlayingLevel });
```

We also need to set the videoHeight back to 0 so we dont return early from "checkAdaptation" (videoHeight would be the same height from the first load)

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

https://github.com/jwplayer/jwplayer-commercial/pull/5231

#### Addresses Issue(s):

JW8-1509