### PR TITLE
Set fragPlaying to null in onManifestLoading

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -788,6 +788,7 @@ class StreamController extends TaskLoop {
     this.fragmentTracker.removeAllFragments();
     this.stalled = false;
     this.startPosition = this.lastCurrentTime = 0;
+    this.fragPlaying = null;
   }
 
   onManifestParsed (data) {
@@ -809,7 +810,6 @@ class StreamController extends TaskLoop {
 
     this.levels = data.levels;
     this.startFragRequested = false;
-    this.fragPlaying = null;
     let config = this.config;
     if (config.autoStartLoad || this.forceStartLoad)
       this.hls.startLoad(config.startPosition);


### PR DESCRIPTION
### This PR will...

Set fragPlaying to null in "onManfiestLoading" function instead of "onManifestLoaded"

### Why is this Pull Request needed?

The current frag should be reset before the manifest was loaded so we don't impact single manifest live streams. 

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?

#### Addresses Issue(s):

JW8-1509