### PR TITLE
Improve searching via PDT

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -28,7 +28,7 @@ export var hlsDefaultConfig = {
   capLevelOnFPSDrop: false, // used by fps-controller
   capLevelToPlayerSize: false, // used by cap-level-controller
   initialLiveManifestSize: 1, // used by stream-controller
-  maxBufferLength: 1, // used by stream-controller
+  maxBufferLength: 30, // used by stream-controller
   maxBufferSize: 60 * 1000 * 1000, // used by stream-controller
   maxBufferHole: 0.5, // used by stream-controller
 
@@ -42,7 +42,7 @@ export var hlsDefaultConfig = {
   liveSyncDuration: undefined, // used by stream-controller
   liveMaxLatencyDuration: undefined, // used by stream-controller
   liveDurationInfinity: false, // used by buffer-controller
-  maxMaxBufferLength: 1, // used by stream-controller
+  maxMaxBufferLength: 600, // used by stream-controller
   enableWorker: true, // used by demuxer
   enableSoftwareAES: true, // used by decrypter
   manifestLoadingTimeOut: 10000, // used by playlist-loader

--- a/src/config.js
+++ b/src/config.js
@@ -28,7 +28,7 @@ export var hlsDefaultConfig = {
   capLevelOnFPSDrop: false, // used by fps-controller
   capLevelToPlayerSize: false, // used by cap-level-controller
   initialLiveManifestSize: 1, // used by stream-controller
-  maxBufferLength: 30, // used by stream-controller
+  maxBufferLength: 1, // used by stream-controller
   maxBufferSize: 60 * 1000 * 1000, // used by stream-controller
   maxBufferHole: 0.5, // used by stream-controller
 
@@ -42,7 +42,7 @@ export var hlsDefaultConfig = {
   liveSyncDuration: undefined, // used by stream-controller
   liveMaxLatencyDuration: undefined, // used by stream-controller
   liveDurationInfinity: false, // used by buffer-controller
-  maxMaxBufferLength: 600, // used by stream-controller
+  maxMaxBufferLength: 1, // used by stream-controller
   enableWorker: true, // used by demuxer
   enableSoftwareAES: true, // used by decrypter
   manifestLoadingTimeOut: 10000, // used by playlist-loader

--- a/src/controller/abr-controller.js
+++ b/src/controller/abr-controller.js
@@ -136,7 +136,7 @@ class AbrController extends EventHandler {
 
   onFragLoaded (data) {
     let frag = data.frag;
-    if (frag.type === 'main' && !isNaN(frag.sn)) {
+    if (frag.type === 'main' && Number.isFinite(frag.sn)) {
       // stop monitoring bw once frag loaded
       this.clearTimer();
       // store level id after successful fragment load
@@ -167,7 +167,7 @@ class AbrController extends EventHandler {
     // if same frag is loaded multiple times, it might be in browser cache, and loaded quickly
     // and leading to wrong bw estimation
     // on bitrate test, also only update stats once (if tload = tbuffered == on FRAG_LOADED)
-    if (stats.aborted !== true && frag.type === 'main' && !isNaN(frag.sn) && ((!frag.bitrateTest || stats.tload === stats.tbuffered))) {
+    if (stats.aborted !== true && frag.type === 'main' && Number.isFinite(frag.sn) && ((!frag.bitrateTest || stats.tload === stats.tbuffered))) {
       // use tparsed-trequest instead of tbuffered-trequest to compute fragLoadingProcessing; rationale is that  buffer appending only happens once media is attached
       // in case we use config.startFragPrefetch while media is not attached yet, fragment might be parsed while media not attached yet, but it will only be buffered on media attached
       // as a consequence it could happen really late in the process. meaning that appending duration might appears huge ... leading to underestimated throughput estimation

--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -326,7 +326,7 @@ class AudioStreamController extends TaskLoop {
             if (this.fragmentTracker.getState(frag) === FragmentState.NOT_LOADED) {
               this.fragCurrent = frag;
               this.startFragRequested = true;
-              if (!isNaN(frag.sn))
+              if (Number.isFinite(frag.sn))
                 this.nextLoadPosition = frag.start + frag.duration;
 
               hls.trigger(Event.FRAG_LOADING, { frag });
@@ -506,7 +506,7 @@ class AudioStreamController extends TaskLoop {
       if (this.startPosition === -1) {
         // first, check if start time offset has been set in playlist, if yes, use this value
         let startTimeOffset = newDetails.startTimeOffset;
-        if (!isNaN(startTimeOffset)) {
+        if (Number.isFinite(startTimeOffset)) {
           logger.log(`start time offset found in playlist, adjust startPosition to ${startTimeOffset}`);
           this.startPosition = startTimeOffset;
         } else {
@@ -632,7 +632,7 @@ class AudioStreamController extends TaskLoop {
         track = this.tracks[trackId],
         hls = this.hls;
 
-      if (isNaN(data.endPTS)) {
+      if (!Number.isFinite(data.endPTS)) {
         data.endPTS = data.startPTS + fragCurrent.duration;
         data.endDTS = data.startDTS + fragCurrent.duration;
       }

--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -409,7 +409,7 @@ class BufferController extends EventHandler {
       (duration === Infinity || isNaN(duration))) {
       // levelDuration was the last value we set.
       // not using mediaSource.duration as the browser may tweak this value
-      // only update Media Source duration if its value increase, this is to avoid
+      // only `update Media Source duration if its value increase, this is to avoid
       // flushing already buffered portion when switching between quality level
       logger.log(`Updating Media Source duration to ${this._levelDuration.toFixed(3)}`);
       this._msDuration = this.mediaSource.duration = this._levelDuration;

--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -406,7 +406,7 @@ class BufferController extends EventHandler {
       logger.log('Media Source duration is set to Infinity');
       this._msDuration = this.mediaSource.duration = Infinity;
     } else if ((this._levelDuration > this._msDuration && this._levelDuration > duration) ||
-      (duration === Infinity || isNaN(duration))) {
+      (duration === Infinity || !Number.isFinite(duration))) {
       // levelDuration was the last value we set.
       // not using mediaSource.duration as the browser may tweak this value
       // only update Media Source duration if its value increase, this is to avoid

--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -405,8 +405,7 @@ class BufferController extends EventHandler {
       // Override duration to Infinity
       logger.log('Media Source duration is set to Infinity');
       this._msDuration = this.mediaSource.duration = Infinity;
-    } else if ((this._levelDuration > this._msDuration && this._levelDuration > duration) ||
-      (!Number.isFinite(duration))) {
+    } else if ((this._levelDuration > this._msDuration && this._levelDuration > duration) || !Number.isFinite(duration)) {
       // levelDuration was the last value we set.
       // not using mediaSource.duration as the browser may tweak this value
       // only update Media Source duration if its value increase, this is to avoid

--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -409,7 +409,7 @@ class BufferController extends EventHandler {
       (duration === Infinity || isNaN(duration))) {
       // levelDuration was the last value we set.
       // not using mediaSource.duration as the browser may tweak this value
-      // only `update Media Source duration if its value increase, this is to avoid
+      // only update Media Source duration if its value increase, this is to avoid
       // flushing already buffered portion when switching between quality level
       logger.log(`Updating Media Source duration to ${this._levelDuration.toFixed(3)}`);
       this._msDuration = this.mediaSource.duration = this._levelDuration;

--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -406,7 +406,7 @@ class BufferController extends EventHandler {
       logger.log('Media Source duration is set to Infinity');
       this._msDuration = this.mediaSource.duration = Infinity;
     } else if ((this._levelDuration > this._msDuration && this._levelDuration > duration) ||
-      (duration === Infinity || !Number.isFinite(duration))) {
+      (!Number.isFinite(duration))) {
       // levelDuration was the last value we set.
       // not using mediaSource.duration as the browser may tweak this value
       // only update Media Source duration if its value increase, this is to avoid

--- a/src/controller/fragment-finders.js
+++ b/src/controller/fragment-finders.js
@@ -114,12 +114,5 @@ export function fragmentWithinToleranceTest (bufferEnd = 0, maxFragLookUpToleran
  */
 export function pdtWithinToleranceTest (pdtBufferEnd, maxFragLookUpTolerance, candidate) {
   let candidateLookupTolerance = Math.min(maxFragLookUpTolerance, candidate.duration + (candidate.deltaPTS ? candidate.deltaPTS : 0)) * 1000;
-
-  if (candidate.endPdt - candidateLookupTolerance <= pdtBufferEnd) {
-    return false;
-  } else if (candidate.pdt && candidate.pdt - candidateLookupTolerance > pdtBufferEnd) {
-    return false;
-  }
-
-  return true;
+  return candidate.endPdt - candidateLookupTolerance > pdtBufferEnd;
 }

--- a/src/controller/fragment-finders.js
+++ b/src/controller/fragment-finders.js
@@ -44,7 +44,12 @@ export function findFragmentByPDT (fragments, PDTValue = null, maxFragLookUpTole
     return null;
   }
 
-  return BinarySearch.search(fragments, pdtWithinToleranceTest.bind(null, PDTValue, maxFragLookUpTolerance));
+  for (let seg = 0; seg < fragments.length; ++seg) {
+    let frag = fragments[seg];
+    if (pdtWithinToleranceTest(PDTValue, maxFragLookUpTolerance, frag)) {
+      return frag;
+    }
+  }
 }
 
 /**
@@ -105,16 +110,16 @@ export function fragmentWithinToleranceTest (bufferEnd = 0, maxFragLookUpToleran
  * @param {*} candidate - The fragment to test
  * @param {number} [pdtBufferEnd = 0] - The Unix time representing the end of the current buffered range
  * @param {number} [maxFragLookUpTolerance = 0] - The amount of time that a fragment's start can be within in order to be considered contiguous
- * @returns {number} - 0 if it matches, 1 if too low, -1 if too high
+ * @returns {boolean} True if contiguous, false otherwise
  */
 export function pdtWithinToleranceTest (pdtBufferEnd, maxFragLookUpTolerance, candidate) {
   let candidateLookupTolerance = Math.min(maxFragLookUpTolerance, candidate.duration + (candidate.deltaPTS ? candidate.deltaPTS : 0)) * 1000;
 
   if (candidate.endPdt - candidateLookupTolerance <= pdtBufferEnd) {
-    return 1;
+    return false;
   } else if (candidate.pdt && candidate.pdt - candidateLookupTolerance > pdtBufferEnd) {
-    return -1;
+    return false;
   }
 
-  return 0;
+  return true;
 }

--- a/src/controller/fragment-finders.js
+++ b/src/controller/fragment-finders.js
@@ -1,7 +1,7 @@
 import BinarySearch from '../utils/binary-search';
 
 /**
- * Finds the first fragment whose endPDT value exceeds the given PDT.
+ * Finds the first fragment whose endPDT value exceeds the given PDT, and then returns the
  * @param {Array} fragments - The array of candidate fragments
  * @param {number|null} [PDTValue = null] - The PDT value which must be exceeded
  * @param {number} [maxFragLookUpTolerance = 0] - The amount of time that a fragment's start/end can be within in order to be considered contiguous
@@ -24,7 +24,7 @@ export function findFragmentByPDT (fragments, PDTValue = null, maxFragLookUpTole
   for (let seg = 0; seg < fragments.length; ++seg) {
     let frag = fragments[seg];
     if (pdtWithinToleranceTest(PDTValue, maxFragLookUpTolerance, frag)) {
-      return fragments[seg + 1];
+      return frag;
     }
   }
 }

--- a/src/controller/fragment-finders.js
+++ b/src/controller/fragment-finders.js
@@ -1,25 +1,6 @@
 import BinarySearch from '../utils/binary-search';
 
 /**
- * Calculates the PDT of the next load position.
- * bufferEnd in this function is usually the position of the playhead.
- * @param {number} [start = 0] - The PTS of the first fragment within the level
- * @param {number} [bufferEnd = 0] - The end of the contiguous buffered range the playhead is currently within
- * @param {*} levelDetails - An object containing the parsed and computed properties of the currently playing level
- * @returns {number} nextPdt - The computed PDT
- */
-export function calculateNextPDT (start = 0, bufferEnd = 0, levelDetails) {
-  let pdt = 0;
-  if (levelDetails.programDateTime) {
-    const parsedDateInt = Date.parse(levelDetails.programDateTime);
-    if (!isNaN(parsedDateInt)) {
-      pdt = (bufferEnd * 1000) + parsedDateInt - (1000 * start);
-    }
-  }
-  return pdt;
-}
-
-/**
  * Finds the first fragment whose endPDT value exceeds the given PDT.
  * @param {Array} fragments - The array of candidate fragments
  * @param {number|null} [PDTValue = null] - The PDT value which must be exceeded
@@ -32,22 +13,18 @@ export function findFragmentByPDT (fragments, PDTValue = null, maxFragLookUpTole
   }
 
   // if less than start
-  let firstSegment = fragments[0];
-
-  if (PDTValue < firstSegment.pdt) {
+  if (PDTValue < fragments[0].pdt) {
     return null;
   }
 
-  let lastSegment = fragments[fragments.length - 1];
-
-  if (PDTValue >= lastSegment.endPdt) {
+  if (PDTValue >= fragments[fragments.length - 1].endPdt) {
     return null;
   }
 
   for (let seg = 0; seg < fragments.length; ++seg) {
     let frag = fragments[seg];
     if (pdtWithinToleranceTest(PDTValue, maxFragLookUpTolerance, frag)) {
-      return frag;
+      return fragments[seg + 1];
     }
   }
 }

--- a/src/controller/fragment-finders.js
+++ b/src/controller/fragment-finders.js
@@ -39,7 +39,7 @@ export function findFragmentByPDT (fragments, PDTValue = null, maxFragLookUpTole
  * @param {number} maxFragLookUpTolerance - The amount of time that a fragment's start/end can be within in order to be considered contiguous
  * @returns {*} foundFrag - The best matching fragment
  */
-export function findFragmentBySN (fragPrevious, fragments, bufferEnd = 0, maxFragLookUpTolerance = 0) {
+export function findFragmentByPTS (fragPrevious, fragments, bufferEnd = 0, maxFragLookUpTolerance = 0) {
   const fragNext = fragPrevious ? fragments[fragPrevious.sn - fragments[0].sn + 1] : null;
   // Prefer the next fragment if it's within tolerance
   if (fragNext && !fragmentWithinToleranceTest(bufferEnd, maxFragLookUpTolerance, fragNext)) {

--- a/src/controller/fragment-finders.js
+++ b/src/controller/fragment-finders.js
@@ -1,14 +1,14 @@
 import BinarySearch from '../utils/binary-search';
 
 /**
- * Finds the first fragment whose endPDT value exceeds the given PDT, and then returns the
+ * Returns first fragment whose endPdt value exceeds the given PDT.
  * @param {Array} fragments - The array of candidate fragments
  * @param {number|null} [PDTValue = null] - The PDT value which must be exceeded
  * @param {number} [maxFragLookUpTolerance = 0] - The amount of time that a fragment's start/end can be within in order to be considered contiguous
  * @returns {*|null} fragment - The best matching fragment
  */
-export function findFragmentByPDT (fragments, PDTValue = null, maxFragLookUpTolerance = 0) {
-  if (!fragments || !fragments.length || PDTValue === null) {
+export function findFragmentByPDT (fragments, PDTValue, maxFragLookUpTolerance) {
+  if (!fragments || !fragments.length || !Number.isFinite(PDTValue)) {
     return null;
   }
 
@@ -21,6 +21,7 @@ export function findFragmentByPDT (fragments, PDTValue = null, maxFragLookUpTole
     return null;
   }
 
+  maxFragLookUpTolerance = maxFragLookUpTolerance || 0;
   for (let seg = 0; seg < fragments.length; ++seg) {
     let frag = fragments[seg];
     if (pdtWithinToleranceTest(PDTValue, maxFragLookUpTolerance, frag)) {

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -359,7 +359,7 @@ class StreamController extends TaskLoop {
           }
         } else { // Relies on PDT in order to switch bitrates (Support EXT-X-DISCONTINUITY without EXT-X-DISCONTINUITY-SEQUENCE)
           logger.log(`live playlist, switching playlist, load frag with same PDT: ${fragPrevious.pdt}`);
-          frag = findFragmentByPDT(fragments, fragPrevious.pdt, config.maxFragLookUpTolerance);
+          frag = findFragmentByPDT(fragments, fragPrevious.endPdt, config.maxFragLookUpTolerance);
         }
       }
       if (!frag) {
@@ -407,9 +407,6 @@ class StreamController extends TaskLoop {
             } else {
               frag = nextFrag;
               logger.log(`SN just loaded, load next one: ${frag.sn}`, frag);
-              if (frag.start > bufferEnd) {
-                debugger;
-              }
             }
           } else {
             frag = null;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -847,7 +847,7 @@ class StreamController extends TaskLoop {
       if (this.startPosition === -1 || this.lastCurrentTime === -1) {
         // first, check if start time offset has been set in playlist, if yes, use this value
         let startTimeOffset = newDetails.startTimeOffset;
-        if (!isNaN(startTimeOffset)) {
+        if (!Number.isFinite(startTimeOffset)) {
           if (startTimeOffset < 0) {
             logger.log(`negative start time offset ${startTimeOffset}, count from end of last fragment`);
             startTimeOffset = sliding + duration + startTimeOffset;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -449,7 +449,7 @@ class StreamController extends TaskLoop {
       this.fragCurrent = frag;
       this.startFragRequested = true;
       // Don't update nextLoadPosition for fragments which are not buffered
-      if (!isNaN(frag.sn) && !frag.bitrateTest)
+      if (Number.isFinite(frag.sn) && !frag.bitrateTest)
         this.nextLoadPosition = frag.start + frag.duration;
 
       // Allow backtracked fragments to load
@@ -712,7 +712,7 @@ class StreamController extends TaskLoop {
 
   onMediaSeeking () {
     let media = this.media, currentTime = media ? media.currentTime : undefined, config = this.config;
-    if (!isNaN(currentTime))
+    if (Number.isFinite(currentTime))
       logger.log(`media seeking to ${currentTime.toFixed(3)}`);
 
     let mediaBuffer = this.mediaBuffer ? this.mediaBuffer : media;
@@ -759,7 +759,7 @@ class StreamController extends TaskLoop {
 
   onMediaSeeked () {
     const media = this.media, currentTime = media ? media.currentTime : undefined;
-    if (!isNaN(currentTime))
+    if (Number.isFinite(currentTime))
       logger.log(`media seeked to ${currentTime.toFixed(3)}`);
 
     // tick to speed up FRAGMENT_PLAYING triggering
@@ -823,7 +823,7 @@ class StreamController extends TaskLoop {
         LevelHelper.mergeDetails(curDetails, newDetails);
         sliding = newDetails.fragments[0].start;
         this.liveSyncPosition = this.computeLivePosition(sliding, curDetails);
-        if (newDetails.PTSKnown && !isNaN(sliding)) {
+        if (newDetails.PTSKnown && Number.isFinite(sliding)) {
           logger.log(`live playlist sliding:${sliding.toFixed(3)}`);
         } else {
           logger.log('live playlist - outdated PTS, unknown sliding');
@@ -847,7 +847,7 @@ class StreamController extends TaskLoop {
       if (this.startPosition === -1 || this.lastCurrentTime === -1) {
         // first, check if start time offset has been set in playlist, if yes, use this value
         let startTimeOffset = newDetails.startTimeOffset;
-        if (!Number.isFinite(startTimeOffset)) {
+        if (Number.isFinite(startTimeOffset)) {
           if (startTimeOffset < 0) {
             logger.log(`negative start time offset ${startTimeOffset}, count from end of last fragment`);
             startTimeOffset = sliding + duration + startTimeOffset;
@@ -1026,7 +1026,7 @@ class StreamController extends TaskLoop {
         this.state === State.PARSING) {
       let level = this.levels[this.level],
         frag = fragCurrent;
-      if (isNaN(data.endPTS)) {
+      if (!Number.isFinite(data.endPTS)) {
         data.endPTS = data.startPTS + fragCurrent.duration;
         data.endDTS = data.startDTS + fragCurrent.duration;
       }

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -59,7 +59,6 @@ class StreamController extends TaskLoop {
     this.audioCodecSwap = false;
     this._state = State.STOPPED;
     this.stallReported = false;
-    this.lastPdt = 0;
   }
 
   onHandlerDestroying () {
@@ -360,7 +359,7 @@ class StreamController extends TaskLoop {
           }
         } else { // Relies on PDT in order to switch bitrates (Support EXT-X-DISCONTINUITY without EXT-X-DISCONTINUITY-SEQUENCE)
           logger.log(`live playlist, switching playlist, load frag with same PDT: ${fragPrevious.pdt}`);
-          frag = findFragmentByPDT(fragments, fragPrevious.endPdt, config.maxFragLookUpTolerance);
+          frag = findFragmentByPDT(fragments, fragPrevious.pdt, config.maxFragLookUpTolerance);
         }
       }
       if (!frag) {
@@ -407,7 +406,10 @@ class StreamController extends TaskLoop {
               logger.warn('SN just loaded, with large PTS gap between audio and video, maybe frag is not starting with a keyframe ? load previous one to try to overcome this');
             } else {
               frag = nextFrag;
-              logger.log(`SN just loaded, load next one: ${frag.sn}`);
+              logger.log(`SN just loaded, load next one: ${frag.sn}`, frag);
+              if (frag.start > bufferEnd) {
+                debugger;
+              }
             }
           } else {
             frag = null;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -300,13 +300,11 @@ class StreamController extends TaskLoop {
     if (!frag)
       frag = this._findFragment(start, fragPrevious, fragLen, fragments, bufferEnd, end, levelDetails);
 
-    if (frag) {
-        this._loadFragmentOrKey(frag, level, levelDetails, pos, bufferEnd);
-    }
+    if (frag)
+      this._loadFragmentOrKey(frag, level, levelDetails, pos, bufferEnd);
   }
 
   _ensureFragmentAtLivePoint (levelDetails, bufferEnd, start, end, fragPrevious, fragments, fragLen) {
-  fragments.forEach(f => console.log(f.start));
     const config = this.hls.config, media = this.media;
 
     let frag;
@@ -363,7 +361,8 @@ class StreamController extends TaskLoop {
               logger.log(`live playlist, switching playlist, load frag with same CC: ${frag.sn}`);
           }
         } else { // Relies on PDT in order to switch bitrates (Support EXT-X-DISCONTINUITY without EXT-X-DISCONTINUITY-SEQUENCE)
-          frag = findFragmentByPDT(fragments, fragPrevious.pdt, config.maxFragLookUpTolerance);
+          logger.log(`live playlist, switching playlist, load frag with same PDT: ${fragPrevious.pdt}`);
+          frag = findFragmentByPDT(fragments, fragPrevious.endPdt, config.maxFragLookUpTolerance);
         }
       }
       if (!frag) {
@@ -1376,11 +1375,11 @@ class StreamController extends TaskLoop {
     this.levels = data.levels;
   }
 
-  onLevelSwitching() {
+  onLevelSwitching () {
     this.switching = true;
   }
 
-  onLevelSwitched() {
+  onLevelSwitched () {
     this.switched = false;
   }
 

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -15,7 +15,7 @@ import { ErrorTypes, ErrorDetails } from '../errors';
 import { logger } from '../utils/logger';
 import { alignStream } from '../utils/discontinuities';
 import TaskLoop from '../task-loop';
-import { findFragmentByPDT, findFragmentBySN } from './fragment-finders';
+import { findFragmentByPDT, findFragmentByPTS } from './fragment-finders';
 
 export const State = {
   STOPPED: 'STOPPED',
@@ -382,7 +382,7 @@ class StreamController extends TaskLoop {
       const lookupTolerance = (bufferEnd > end - config.maxFragLookUpTolerance) ? 0 : config.maxFragLookUpTolerance;
       // Remove the tolerance if it would put the bufferEnd past the actual end of stream
       // Uses buffer and sequence number to calculate switch segment (required if using EXT-X-DISCONTINUITY-SEQUENCE)
-      frag = findFragmentBySN(fragPrevious, fragments, bufferEnd, lookupTolerance);
+      frag = findFragmentByPTS(fragPrevious, fragments, bufferEnd, lookupTolerance);
     } else {
       // reach end of playlist
       frag = fragments[fragLen - 1];

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -15,7 +15,7 @@ import { ErrorTypes, ErrorDetails } from '../errors';
 import { logger } from '../utils/logger';
 import { alignDiscontinuities } from '../utils/discontinuities';
 import TaskLoop from '../task-loop';
-import { calculateNextPDT, findFragmentByPDT, findFragmentBySN, fragmentWithinToleranceTest } from './fragment-finders';
+import { calculateNextPDT, findFragmentByPDT, findFragmentBySN } from './fragment-finders';
 
 export const State = {
   STOPPED: 'STOPPED',
@@ -374,29 +374,27 @@ class StreamController extends TaskLoop {
 
   _findFragment (start, fragPrevious, fragLen, fragments, bufferEnd, end, levelDetails) {
     const config = this.hls.config;
-    const fragBySN = () => findFragmentBySN(fragPrevious, fragments, bufferEnd, end, config.maxFragLookUpTolerance);
     let frag;
-    let foundFrag;
 
     if (bufferEnd < end) {
-      if (!levelDetails.programDateTime) { // Uses buffer and sequence number to calculate switch segment (required if using EXT-X-DISCONTINUITY-SEQUENCE)
-        foundFrag = fragBySN();
+      // Remove the tolerance if it would put the bufferEnd past the actual end of stream
+      const lookupTolerance = (bufferEnd > end - config.maxFragLookUpTolerance) ? 0 : config.maxFragLookUpTolerance;
+      if (!levelDetails.programDateTime) {
+        // Uses buffer and sequence number to calculate switch segment (required if using EXT-X-DISCONTINUITY-SEQUENCE)
+        frag = findFragmentBySN(fragPrevious, fragments, bufferEnd, lookupTolerance);
       } else {
         // Relies on PDT in order to switch bitrates (Support EXT-X-DISCONTINUITY without EXT-X-DISCONTINUITY-SEQUENCE)
-        foundFrag = findFragmentByPDT(fragments, calculateNextPDT(start, bufferEnd, levelDetails));
-        if (!foundFrag || fragmentWithinToleranceTest(bufferEnd, config.maxFragLookUpTolerance, foundFrag)) {
-          // Fall back to SN order if finding by PDT returns a frag which won't fit within the stream
-          // fragmentWithToleranceTest returns 0 if the frag is within tolerance; 1 or -1 otherwise
+        frag = findFragmentByPDT(fragments, calculateNextPDT(start, bufferEnd, levelDetails), lookupTolerance);
+        if (!frag) {
           logger.warn('Frag found by PDT search did not fit within tolerance; falling back to finding by SN');
-          foundFrag = fragBySN();
+          frag = findFragmentBySN(fragPrevious, fragments, bufferEnd, lookupTolerance);
         }
       }
     } else {
       // reach end of playlist
-      foundFrag = fragments[fragLen - 1];
+      frag = fragments[fragLen - 1];
     }
-    if (foundFrag) {
-      frag = foundFrag;
+    if (frag) {
       const curSNIdx = frag.sn - levelDetails.startSN;
       const sameLevel = fragPrevious && frag.level === fragPrevious.level;
       const prevFrag = fragments[curSNIdx - 1];

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -51,9 +51,7 @@ class StreamController extends TaskLoop {
       Event.BUFFER_CREATED,
       Event.BUFFER_APPENDED,
       Event.BUFFER_FLUSHED,
-      Event.LEVELS_UPDATED,
-      Event.LEVEL_SWITCHING,
-      Event.LEVEL_SWITCHED
+      Event.LEVELS_UPDATED
     );
 
     this.fragmentTracker = fragmentTracker;
@@ -1373,14 +1371,6 @@ class StreamController extends TaskLoop {
 
   onLevelsUpdated (data) {
     this.levels = data.levels;
-  }
-
-  onLevelSwitching () {
-    this.switching = true;
-  }
-
-  onLevelSwitched () {
-    this.switched = false;
   }
 
   swapAudioCodec () {

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -339,7 +339,12 @@ class StreamController extends TaskLoop {
          even if SN are not synchronized between playlists, loading this frag will help us
          compute playlist sliding and find the right one after in case it was not the right consecutive one */
       if (fragPrevious) {
-        if (!levelDetails.hasProgramDateTime) { // Uses buffer and sequence number to calculate switch segment (required if using EXT-X-DISCONTINUITY-SEQUENCE)
+        if (levelDetails.hasProgramDateTime) {
+          // Relies on PDT in order to switch bitrates (Support EXT-X-DISCONTINUITY without EXT-X-DISCONTINUITY-SEQUENCE)
+          logger.log(`live playlist, switching playlist, load frag with same PDT: ${fragPrevious.pdt}`);
+          frag = findFragmentByPDT(fragments, fragPrevious.endPdt, config.maxFragLookUpTolerance);
+        } else {
+          // Uses buffer and sequence number to calculate switch segment (required if using EXT-X-DISCONTINUITY-SEQUENCE)
           const targetSN = fragPrevious.sn + 1;
           if (targetSN >= levelDetails.startSN && targetSN <= levelDetails.endSN) {
             const fragNext = fragments[targetSN - levelDetails.startSN];
@@ -357,9 +362,6 @@ class StreamController extends TaskLoop {
             if (frag)
               logger.log(`live playlist, switching playlist, load frag with same CC: ${frag.sn}`);
           }
-        } else { // Relies on PDT in order to switch bitrates (Support EXT-X-DISCONTINUITY without EXT-X-DISCONTINUITY-SEQUENCE)
-          logger.log(`live playlist, switching playlist, load frag with same PDT: ${fragPrevious.pdt}`);
-          frag = findFragmentByPDT(fragments, fragPrevious.endPdt, config.maxFragLookUpTolerance);
         }
       }
       if (!frag) {

--- a/src/demux/demuxer.js
+++ b/src/demux/demuxer.js
@@ -93,7 +93,7 @@ class Demuxer {
 
   push (data, initSegment, audioCodec, videoCodec, frag, duration, accurateTimeOffset, defaultInitPTS) {
     const w = this.w;
-    const timeOffset = !isNaN(frag.startDTS) ? frag.startDTS : frag.start;
+    const timeOffset = Number.isFinite(frag.startDTS) ? frag.startDTS : frag.start;
     const decryptdata = frag.decryptdata;
     const lastFrag = this.frag;
     const discontinuity = !(lastFrag && (frag.cc === lastFrag.cc));

--- a/src/helper/fragment-tracker.js
+++ b/src/helper/fragment-tracker.js
@@ -103,7 +103,7 @@ export class FragmentTracker extends EventHandler {
       fragmentEntity.buffered = true;
 
       Object.keys(this.timeRanges).forEach(elementaryStream => {
-        if (fragment.hasElementaryStream(elementaryStream) === true) {
+        if (fragment.hasElementaryStream(elementaryStream)) {
           let timeRange = this.timeRanges[elementaryStream];
           // Check for malformed fragments
           // Gaps need to be calculated for each elementaryStream

--- a/src/helper/fragment-tracker.js
+++ b/src/helper/fragment-tracker.js
@@ -229,7 +229,7 @@ export class FragmentTracker extends EventHandler {
   onFragLoaded (e) {
     let fragment = e.frag;
     // dont track initsegment (for which sn is not a number)
-    if (!isNaN(fragment.sn)) {
+    if (Number.isFinite(fragment.sn)) {
       let fragKey = this.getFragmentKey(fragment);
       let fragmentEntity = {
         body: fragment,

--- a/src/helper/level-helper.js
+++ b/src/helper/level-helper.js
@@ -7,7 +7,7 @@ import { logger } from '../utils/logger';
 export function updatePTS (fragments, fromIdx, toIdx) {
   let fragFrom = fragments[fromIdx], fragTo = fragments[toIdx], fragToPTS = fragTo.startPTS;
   // if we know startPTS[toIdx]
-  if (!isNaN(fragToPTS)) {
+  if (Number.isFinite(fragToPTS)) {
     // update fragment duration.
     // it helps to fix drifts between playlist reported duration and fragment real duration
     if (toIdx > fromIdx) {
@@ -31,10 +31,10 @@ export function updatePTS (fragments, fromIdx, toIdx) {
 export function updateFragPTSDTS (details, frag, startPTS, endPTS, startDTS, endDTS) {
   // update frag PTS/DTS
   let maxStartPTS = startPTS;
-  if (!isNaN(frag.startPTS)) {
+  if (Number.isFinite(frag.startPTS)) {
     // delta PTS between audio and video
     let deltaPTS = Math.abs(frag.startPTS - startPTS);
-    if (isNaN(frag.deltaPTS))
+    if (!Number.isFinite(frag.deltaPTS))
       frag.deltaPTS = deltaPTS;
     else
       frag.deltaPTS = Math.max(deltaPTS, frag.deltaPTS);
@@ -106,7 +106,7 @@ export function mergeDetails (oldDetails, newDetails) {
       newFrag = newfragments[i];
     if (newFrag && oldFrag) {
       ccOffset = oldFrag.cc - newFrag.cc;
-      if (!isNaN(oldFrag.startPTS)) {
+      if (Number.isFinite(oldFrag.startPTS)) {
         newFrag.start = newFrag.startPTS = oldFrag.startPTS;
         newFrag.endPTS = oldFrag.endPTS;
         newFrag.duration = oldFrag.duration;

--- a/src/helper/level-helper.js
+++ b/src/helper/level-helper.js
@@ -64,7 +64,7 @@ export function updateFragPTSDTS (details, frag, startPTS, endPTS, startDTS, end
   fragments = details.fragments;
   // update frag reference in fragments array
   // rationale is that fragments array might not contain this frag object.
-  // this will happpen if playlist has been refreshed between frag loading and call to updateFragPTSDTS()
+  // this will happen if playlist has been refreshed between frag loading and call to updateFragPTSDTS()
   // if we don't update frag, we won't be able to propagate PTS info on the playlist
   // resulting in invalid sliding computation
   fragments[fragIdx] = frag;
@@ -77,7 +77,7 @@ export function updateFragPTSDTS (details, frag, startPTS, endPTS, startDTS, end
     updatePTS(fragments, i, i + 1);
 
   details.PTSKnown = true;
-  // logger.log(`                                            frag start/end:${startPTS.toFixed(3)}/${endPTS.toFixed(3)}`);
+  // logger.log(`frag start/end:${startPTS.toFixed(3)}/${endPTS.toFixed(3)}`);
 
   return drift;
 }

--- a/src/loader/fragment-loader.js
+++ b/src/loader/fragment-loader.js
@@ -52,7 +52,7 @@ class FragmentLoader extends EventHandler {
     let start = frag.byteRangeStartOffset,
       end = frag.byteRangeEndOffset;
 
-    if (!isNaN(start) && !isNaN(end)) {
+    if (Number.isFinite(start) && Number.isFinite(end)) {
       loaderContext.rangeStart = start;
       loaderContext.rangeEnd = end;
     }

--- a/src/loader/fragment.js
+++ b/src/loader/fragment.js
@@ -82,7 +82,7 @@ export default class Fragment {
 
   get endPdt () {
     if (!Number.isFinite(this.pdt))
-      return 0;
+      return null;
 
     let duration = !Number.isFinite(this.duration) ? 0 : this.duration;
 

--- a/src/loader/fragment.js
+++ b/src/loader/fragment.js
@@ -81,10 +81,12 @@ export default class Fragment {
   }
 
   get endPdt () {
-    if (!this.pdt)
+    if (isNaN(this.pdt))
       return 0;
 
-    return this.pdt + (this.duration * 1000);
+    let duration = isNaN(this.duration) ? 0 : this.duration;
+
+    return this.pdt + (duration * 1000);
   }
 
   /**

--- a/src/loader/fragment.js
+++ b/src/loader/fragment.js
@@ -87,11 +87,11 @@ export default class Fragment {
 
     return this._decryptdata;
   }
-  
-  get endPdt() {
-    if (!this.pdt) {
+
+  get endPdt () {
+    if (!this.pdt)
       return 0;
-    }
+
     return this.pdt + (this.duration * 1000);
   }
 

--- a/src/loader/fragment.js
+++ b/src/loader/fragment.js
@@ -9,6 +9,8 @@ export default class Fragment {
     this._byteRange = null;
     this._decryptdata = null;
     this.tagList = [];
+    this.pdt = null;
+    this.rawProgramDateTime = null;
 
     // Holds the types of data this fragment supports
     this._elementaryStreams = {

--- a/src/loader/fragment.js
+++ b/src/loader/fragment.js
@@ -81,10 +81,10 @@ export default class Fragment {
   }
 
   get endPdt () {
-    if (isNaN(this.pdt))
+    if (!Number.isFinite(this.pdt))
       return 0;
 
-    let duration = isNaN(this.duration) ? 0 : this.duration;
+    let duration = !Number.isFinite(this.duration) ? 0 : this.duration;
 
     return this.pdt + (duration * 1000);
   }

--- a/src/loader/fragment.js
+++ b/src/loader/fragment.js
@@ -9,6 +9,7 @@ export default class Fragment {
     this._byteRange = null;
     this._decryptdata = null;
     this.tagList = [];
+    this.pdt = null;
 
     // Holds the types of data this fragment supports
     this._elementaryStreams = {
@@ -85,6 +86,13 @@ export default class Fragment {
       this._decryptdata = this.fragmentDecryptdataFromLevelkey(this.levelkey, this.sn);
 
     return this._decryptdata;
+  }
+  
+  get endPdt() {
+    if (!this.pdt) {
+      return 0;
+    }
+    return this.pdt + (this.duration * 1000);
   }
 
   /**

--- a/src/loader/fragment.js
+++ b/src/loader/fragment.js
@@ -9,7 +9,6 @@ export default class Fragment {
     this._byteRange = null;
     this._decryptdata = null;
     this.tagList = [];
-    this.pdt = null;
 
     // Holds the types of data this fragment supports
     this._elementaryStreams = {
@@ -39,13 +38,6 @@ export default class Fragment {
 
   set url (value) {
     this._url = value;
-  }
-
-  get programDateTime () {
-    if (!this._programDateTime && this.rawProgramDateTime)
-      this._programDateTime = new Date(Date.parse(this.rawProgramDateTime));
-
-    return this._programDateTime;
   }
 
   get byteRange () {

--- a/src/loader/level.js
+++ b/src/loader/level.js
@@ -18,6 +18,6 @@ export default class Level {
   }
 
   get hasProgramDateTime () {
-    return this.fragments.length && !isNaN(this.fragments[0].pdt);
+    return !!(this.fragments[0] && !isNaN(this.fragments[0].pdt));
   }
 }

--- a/src/loader/level.js
+++ b/src/loader/level.js
@@ -1,0 +1,23 @@
+export default class Level {
+  constructor (baseUrl) {
+    // Please keep properties in alphabetical order
+    this.endCC = 0;
+    this.endSN = 0;
+    this.fragments = [];
+    this.initSegment = null;
+    this.live = true;
+    this.needSidxRanges = false;
+    this.startCC = 0;
+    this.startSN = 0;
+    this.startTimeOffset = null;
+    this.targetduration = 0;
+    this.totalduration = 0;
+    this.type = null;
+    this.url = baseUrl;
+    this.version = null;
+  }
+
+  get hasProgramDateTime () {
+    return this.fragments.length && !isNaN(this.fragments[0].pdt);
+  }
+}

--- a/src/loader/level.js
+++ b/src/loader/level.js
@@ -18,6 +18,6 @@ export default class Level {
   }
 
   get hasProgramDateTime () {
-    return !!(this.fragments[0] && !isNaN(this.fragments[0].pdt));
+    return !!(this.fragments[0] && Number.isFinite(this.fragments[0].pdt));
   }
 }

--- a/src/loader/m3u8-parser.js
+++ b/src/loader/m3u8-parser.js
@@ -2,6 +2,7 @@
 import URLToolkit from 'url-toolkit';
 
 import Fragment from './fragment';
+import Level from './level';
 import LevelKey from './level-key';
 
 import AttrList from '../utils/attr-list';
@@ -82,7 +83,6 @@ export default class M3U8Parser {
 
     while ((result = MASTER_PLAYLIST_REGEX.exec(string)) != null) {
       const level = {};
-
       let attrs = level.attrs = new AttrList(result[1]);
       level.url = M3U8Parser.resolve(result[2], baseurl);
 
@@ -139,23 +139,15 @@ export default class M3U8Parser {
   }
 
   static parseLevelPlaylist (string, baseurl, id, type) {
-    let currentSN = 0,
-      totalduration = 0,
-      level = {
-        type: null,
-        version: null,
-        url: baseurl,
-        fragments: [],
-        live: true,
-        startSN: 0,
-        hasProgramDateTime: false
-      },
-      levelkey = new LevelKey(),
-      cc = 0,
-      prevFrag = null,
-      frag = new Fragment(),
-      result,
-      i;
+    let currentSN = 0;
+    let totalduration = 0;
+    let level = new Level(baseurl);
+    let levelkey = new LevelKey();
+    let cc = 0;
+    let prevFrag = null;
+    let frag = new Fragment();
+    let result;
+    let i;
 
     let firstPdtIndex = null;
 
@@ -202,7 +194,6 @@ export default class M3U8Parser {
         frag.tagList.push(['PROGRAM-DATE-TIME', frag.rawProgramDateTime]);
         if (firstPdtIndex === null)
           firstPdtIndex = level.fragments.length;
-
       } else {
         result = result[0].match(LEVEL_PLAYLIST_REGEX_SLOW);
         for (i = 1; i < result.length; i++) {
@@ -334,7 +325,6 @@ export default class M3U8Parser {
     if (firstPdtIndex)
       backfillProgramDateTimes(level.fragments, firstPdtIndex);
 
-    level.hasProgramDateTime = level.fragments.length && (!isNaN(level.fragments[0].pdt));
     return level;
   }
 }

--- a/src/loader/m3u8-parser.js
+++ b/src/loader/m3u8-parser.js
@@ -185,6 +185,11 @@ export default class M3U8Parser {
             frag.endPdt = frag.pdt + (frag.duration * 1000);
           }
 
+          if (isNaN(frag.pdt)) {
+            frag.pdt = null;
+            frag.endPdt = null;
+          }
+
           level.fragments.push(frag);
           prevFrag = frag;
           totalduration += frag.duration;
@@ -202,8 +207,12 @@ export default class M3U8Parser {
         // avoid sliced strings    https://github.com/video-dev/hls.js/issues/939
         frag.rawProgramDateTime = (' ' + result[5]).slice(1);
         frag.tagList.push(['PROGRAM-DATE-TIME', frag.rawProgramDateTime]);
-        if (level.programDateTime === undefined)
-          level.programDateTime = new Date(new Date(Date.parse(result[5])) - 1000 * totalduration);
+        if (level.programDateTime === undefined) {
+          const pdt = new Date(Date.parse(result[5]) - 1000 * totalduration);
+          if (!isNaN(pdt)) {
+            level.programDateTime = pdt;
+          }
+        }
       } else {
         result = result[0].match(LEVEL_PLAYLIST_REGEX_SLOW);
         for (i = 1; i < result.length; i++) {

--- a/src/loader/m3u8-parser.js
+++ b/src/loader/m3u8-parser.js
@@ -162,7 +162,7 @@ export default class M3U8Parser {
         frag.title = title || null;
         frag.tagList.push(title ? [ 'INF', duration, title ] : [ 'INF', duration ]);
       } else if (result[3]) { // url
-        if (!isNaN(frag.duration)) {
+        if (Number.isFinite(frag.duration)) {
           const sn = currentSN++;
           frag.type = type;
           frag.start = totalduration;
@@ -258,7 +258,7 @@ export default class M3U8Parser {
           let startAttrs = new AttrList(startParams);
           let startTimeOffset = startAttrs.decimalFloatingPoint('TIME-OFFSET');
           // TIME-OFFSET can be 0
-          if (!isNaN(startTimeOffset))
+          if (Number.isFinite(startTimeOffset))
             level.startTimeOffset = startTimeOffset;
 
           break;
@@ -348,7 +348,7 @@ function assignProgramDateTime (frag, prevFrag) {
   else if (prevFrag && prevFrag.pdt)
     frag.pdt = prevFrag.endPdt;
 
-  if (isNaN(frag.pdt)) {
+  if (!Number.isFinite(frag.pdt)) {
     delete frag.pdt;
     delete frag.rawProgramDateTime;
   }

--- a/src/loader/m3u8-parser.js
+++ b/src/loader/m3u8-parser.js
@@ -141,13 +141,15 @@ export default class M3U8Parser {
   static parseLevelPlaylist (string, baseurl, id, type) {
     let currentSN = 0,
       totalduration = 0,
-      level = { type: null, version: null, url: baseurl, fragments: [], live: true, startSN: 0 },
+      level = { type: null, version: null, url: baseurl, fragments: [], live: true, startSN: 0, continuities: [] },
       levelkey = new LevelKey(),
       cc = 0,
       prevFrag = null,
       frag = new Fragment(),
       result,
       i;
+
+    let firstPdtIndex = null;
 
     LEVEL_PLAYLIST_REGEX_FAST.lastIndex = 0;
 
@@ -172,23 +174,7 @@ export default class M3U8Parser {
           // avoid sliced strings    https://github.com/video-dev/hls.js/issues/939
           frag.relurl = (' ' + result[3]).slice(1);
 
-          if (level.programDateTime) {
-            if (prevFrag) {
-              if (frag.rawProgramDateTime) { // PDT discontinuity found
-                frag.pdt = Date.parse(frag.rawProgramDateTime);
-              } else { // Contiguous fragment
-                frag.pdt = prevFrag.pdt + (prevFrag.duration * 1000);
-              }
-            } else { // First fragment
-              frag.pdt = Date.parse(level.programDateTime);
-            }
-            frag.endPdt = frag.pdt + (frag.duration * 1000);
-          }
-
-          if (isNaN(frag.pdt)) {
-            frag.pdt = null;
-            frag.endPdt = null;
-          }
+          assignProgramDateTime(frag, prevFrag);
 
           level.fragments.push(frag);
           prevFrag = frag;
@@ -207,12 +193,10 @@ export default class M3U8Parser {
         // avoid sliced strings    https://github.com/video-dev/hls.js/issues/939
         frag.rawProgramDateTime = (' ' + result[5]).slice(1);
         frag.tagList.push(['PROGRAM-DATE-TIME', frag.rawProgramDateTime]);
-        if (level.programDateTime === undefined) {
-          const pdt = new Date(Date.parse(result[5]) - 1000 * totalduration);
-          if (!isNaN(pdt)) {
-            level.programDateTime = pdt;
-          }
+        if (!firstPdtIndex) {
+          firstPdtIndex = level.fragments.length;
         }
+        level.hasProgramDateTime = true;
       } else {
         result = result[0].match(LEVEL_PLAYLIST_REGEX_SLOW);
         for (i = 1; i < result.length; i++) {
@@ -331,10 +315,44 @@ export default class M3U8Parser {
       }
     }
 
+    /**
+     * Backfill any missing PDT values
+       "If the first EXT-X-PROGRAM-DATE-TIME tag in a Playlist appears after
+       one or more Media Segment URIs, the client SHOULD extrapolate
+       backward from that tag (using EXTINF durations and/or media
+       timestamps) to associate dates with those segments."
+     * We have already extrapolated forward, but all fragments up to the first instance of PDT do not have their PDTs
+     * computed.
+     */
+    if (firstPdtIndex) {
+      backfillProgramDateTimes(level.fragments, firstPdtIndex);
+    }
+
     return level;
   }
 }
 
 function endsWith (str, search) {
   return str.substring(str.length - search.length, str.length) === search;
+}
+
+function backfillProgramDateTimes (fragments, startIndex) {
+  let fragPrev = fragments[startIndex];
+  for (let i = startIndex - 1; i >= 0; i--) {
+    const frag = fragments[i];
+    frag.pdt = fragPrev.pdt - (frag.duration * 1000);
+    fragPrev = frag;
+  }
+}
+
+function assignProgramDateTime (frag, prevFrag) {
+  if (frag.rawProgramDateTime) {
+    frag.pdt = Date.parse(frag.rawProgramDateTime);
+  } else if (prevFrag && prevFrag.pdt) {
+    frag.pdt = prevFrag.endPdt;
+  }
+
+  if (isNaN(frag.pdt)) {
+    frag.pdt = null;
+  }
 }

--- a/src/loader/m3u8-parser.js
+++ b/src/loader/m3u8-parser.js
@@ -274,6 +274,7 @@ export default class M3U8Parser {
           frag.type = type;
           frag.sn = 'initSegment';
           level.initSegment = frag;
+          prevFrag = frag;
           frag = new Fragment();
           break;
         default:

--- a/src/loader/m3u8-parser.js
+++ b/src/loader/m3u8-parser.js
@@ -173,7 +173,6 @@ export default class M3U8Parser {
           frag.baseurl = baseurl;
           // avoid sliced strings    https://github.com/video-dev/hls.js/issues/939
           frag.relurl = (' ' + result[3]).slice(1);
-
           assignProgramDateTime(frag, prevFrag);
 
           level.fragments.push(frag);
@@ -193,9 +192,9 @@ export default class M3U8Parser {
         // avoid sliced strings    https://github.com/video-dev/hls.js/issues/939
         frag.rawProgramDateTime = (' ' + result[5]).slice(1);
         frag.tagList.push(['PROGRAM-DATE-TIME', frag.rawProgramDateTime]);
-        if (!firstPdtIndex) {
+        if (!firstPdtIndex)
           firstPdtIndex = level.fragments.length;
-        }
+
         level.hasProgramDateTime = true;
       } else {
         result = result[0].match(LEVEL_PLAYLIST_REGEX_SLOW);
@@ -274,8 +273,8 @@ export default class M3U8Parser {
           frag.type = type;
           frag.sn = 'initSegment';
           level.initSegment = frag;
-          prevFrag = frag;
           frag = new Fragment();
+          frag.rawProgramDateTime = level.initSegment.rawProgramDateTime;
           break;
         default:
           logger.warn(`line parsed but not handled: ${result}`);
@@ -325,9 +324,8 @@ export default class M3U8Parser {
      * We have already extrapolated forward, but all fragments up to the first instance of PDT do not have their PDTs
      * computed.
      */
-    if (firstPdtIndex) {
+    if (firstPdtIndex)
       backfillProgramDateTimes(level.fragments, firstPdtIndex);
-    }
 
     return level;
   }

--- a/src/loader/m3u8-parser.js
+++ b/src/loader/m3u8-parser.js
@@ -141,7 +141,7 @@ export default class M3U8Parser {
   static parseLevelPlaylist (string, baseurl, id, type) {
     let currentSN = 0,
       totalduration = 0,
-      level = { type: null, version: null, url: baseurl, fragments: [], live: true, startSN: 0, continuities: [] },
+      level = { type: null, version: null, url: baseurl, fragments: [], live: true, startSN: 0 },
       levelkey = new LevelKey(),
       cc = 0,
       prevFrag = null,

--- a/src/loader/m3u8-parser.js
+++ b/src/loader/m3u8-parser.js
@@ -349,7 +349,7 @@ function assignProgramDateTime (frag, prevFrag) {
     frag.pdt = prevFrag.endPdt;
 
   if (!Number.isFinite(frag.pdt)) {
-    delete frag.pdt;
-    delete frag.rawProgramDateTime;
+    frag.pdt = null;
+    frag.rawProgramDateTime = null;
   }
 }

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -333,7 +333,7 @@ class PlaylistLoader extends EventHandler {
 
     const url = PlaylistLoader.getResponseUrl(response, context);
 
-    const levelId = !isNaN(level) ? level : !isNaN(id) ? id : 0; // level -> id -> 0
+    const levelId = Number.isFinite(level) ? level : Number.isFinite(id) ? id : 0; // level -> id -> 0
     const levelType = PlaylistLoader.mapContextToLevelType(context);
 
     const levelDetails = M3U8Parser.parseLevelPlaylist(response.data, url, levelId, levelType);

--- a/src/polyfills/number-isFinite.js
+++ b/src/polyfills/number-isFinite.js
@@ -1,0 +1,3 @@
+export const isFiniteNumber = Number.isFinite || function (value) {
+  return typeof value === 'number' && isFinite(value);
+};

--- a/src/utils/discontinuities.js
+++ b/src/utils/discontinuities.js
@@ -79,6 +79,9 @@ export function adjustPts (sliding, details) {
 export function alignStream (lastFrag, lastLevel, details) {
   alignDiscontinuities(lastFrag, details, lastLevel);
   if (!details.PTSKnown && lastLevel) {
+    // If the PTS wasn't figured out via discontinuity sequence that means there was no CC increase within the level.
+    // Aligning via Program Date Time should therefore be reliable, since PDT should be the same within the same
+    // discontinuity sequence.
     alignPDT(details, lastLevel.details);
   }
 }

--- a/src/utils/discontinuities.js
+++ b/src/utils/discontinuities.js
@@ -119,7 +119,7 @@ export function alignPDT (details, lastDetails) {
     let newPDT = details.fragments[0].pdt;
     // date diff is in ms. frag.start is in seconds
     let sliding = (newPDT - lastPDT) / 1000 + lastDetails.fragments[0].start;
-    if (!isNaN(sliding)) {
+    if (Number.isFinite(sliding)) {
       logger.log(`adjusting PTS using programDateTime delta, sliding:${sliding.toFixed(3)}`);
       adjustPts(sliding, details);
     }

--- a/src/utils/webvtt-parser.js
+++ b/src/utils/webvtt-parser.js
@@ -12,7 +12,7 @@ const cueString2millis = function (timeString) {
   let mins = parseInt(timeString.substr(-9, 2));
   let hours = timeString.length > 9 ? parseInt(timeString.substr(0, timeString.indexOf(':'))) : 0;
 
-  if (isNaN(ts) || isNaN(secs) || isNaN(mins) || isNaN(hours))
+  if (!Number.isFinite(ts) || !Number.isFinite(secs) || !Number.isFinite(mins) || !Number.isFinite(hours))
     return -1;
 
   ts += 1000 * secs;

--- a/tests/unit/controller/fragment-finders.js
+++ b/tests/unit/controller/fragment-finders.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import sinon from 'sinon';
-import { calculateNextPDT, findFragmentByPDT, findFragmentBySN, fragmentWithinToleranceTest, pdtWithinToleranceTest } from '../../../src/controller/fragment-finders';
+import { findFragmentByPDT, findFragmentBySN, fragmentWithinToleranceTest, pdtWithinToleranceTest } from '../../../src/controller/fragment-finders';
 import { mockFragments } from '../../mocks/data';
 import BinarySearch from '../../../src/utils/binary-search';
 
@@ -151,29 +151,6 @@ describe('Fragment finders', function () {
 
     it('returns null when passed an empty frag array', function () {
       assert.strictEqual(findFragmentByPDT([], 9001), null);
-    });
-  });
-
-  describe('calculateNextPDT', function () {
-    const levelDetails = {
-      programDateTime: '2012-12-06T19:10:03+00:00'
-    };
-
-    it('calculates based on levelDetails', function () {
-      const expected = 1354821003000 + (10 * 1000) - (1000 * 5);
-      const actual = calculateNextPDT(5, 10, levelDetails);
-      assert.strictEqual(expected, actual);
-    });
-
-    it('returns 0 if levelDetails does not have programDateTime', function () {
-      const actual = calculateNextPDT(5, 10, {});
-      assert.strictEqual(0, actual);
-    });
-
-    it('returns 0 if the parsed PDT would be NaN', function () {
-      levelDetails.programDateTime = 'foo';
-      const actual = calculateNextPDT(5, 10, levelDetails);
-      assert.strictEqual(0, actual);
     });
   });
 

--- a/tests/unit/controller/fragment-finders.js
+++ b/tests/unit/controller/fragment-finders.js
@@ -130,11 +130,13 @@ describe('Fragment finders', function () {
       const fragments = [
         {
           pdt: 0,
-          endPdt: 1
+          endPdt: 1,
+          duration: 0.001
         },
         {
           pdt: 1,
-          endPdt: 2
+          endPdt: 2,
+          duration: 0.001
         }
       ];
       const actual = findFragmentByPDT(fragments, 0);
@@ -149,10 +151,6 @@ describe('Fragment finders', function () {
 
     it('returns null when passed an empty frag array', function () {
       assert.strictEqual(findFragmentByPDT([], 9001), null);
-    });
-
-    it('accounts for tolerances', function () {
-
     });
   });
 
@@ -202,16 +200,6 @@ describe('Fragment finders', function () {
       assert.strictEqual(false, actual);
     });
 
-    it('returns false if the fragment range is greater than the end of the buffer', function () {
-      const frag = {
-        pdt: pdtBufferEnd + 5000,
-        endPdt: pdtBufferEnd + 10000,
-        duration: 5
-      };
-      const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
-      assert.strictEqual(false, actual);
-    });
-
     it('does not skip very small fragments', function () {
       const frag = {
         pdt: pdtBufferEnd + 200,
@@ -231,16 +219,6 @@ describe('Fragment finders', function () {
       };
       const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
       assert.strictEqual(false, actual);
-    });
-
-    it('accounts for tolerance when checking the pdt of the fragment', function () {
-      const frag = {
-        pdt: pdtBufferEnd + 1,
-        endPdt: pdtBufferEnd + 5000,
-        duration: 5
-      };
-      const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
-      assert.strictEqual(true, actual);
     });
   });
 });

--- a/tests/unit/controller/fragment-finders.js
+++ b/tests/unit/controller/fragment-finders.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import sinon from 'sinon';
-import { findFragmentByPDT, findFragmentBySN, fragmentWithinToleranceTest, pdtWithinToleranceTest } from '../../../src/controller/fragment-finders';
+import { findFragmentByPDT, findFragmentByPTS, fragmentWithinToleranceTest, pdtWithinToleranceTest } from '../../../src/controller/fragment-finders';
 import { mockFragments } from '../../mocks/data';
 import BinarySearch from '../../../src/utils/binary-search';
 
@@ -21,7 +21,7 @@ describe('Fragment finders', function () {
   };
   const bufferEnd = fragPrevious.start + fragPrevious.duration;
 
-  describe('findFragmentBySN', function () {
+  describe('findFragmentByPTS', function () {
     let tolerance = 0.25;
     let binarySearchSpy;
     beforeEach(function () {
@@ -29,21 +29,21 @@ describe('Fragment finders', function () {
     });
 
     it('finds a fragment with SN sequential to the previous fragment', function () {
-      const foundFragment = findFragmentBySN(fragPrevious, mockFragments, bufferEnd, tolerance);
+      const foundFragment = findFragmentByPTS(fragPrevious, mockFragments, bufferEnd, tolerance);
       const resultSN = foundFragment ? foundFragment.sn : -1;
       assert.equal(foundFragment, mockFragments[3], 'Expected sn 3, found sn segment ' + resultSN);
       assert(binarySearchSpy.notCalled);
     });
 
     it('chooses the fragment with the next SN if its contiguous with the end of the buffer', function () {
-      const actual = findFragmentBySN(mockFragments[0], mockFragments, mockFragments[0].duration, tolerance);
+      const actual = findFragmentByPTS(mockFragments[0], mockFragments, mockFragments[0].duration, tolerance);
       assert.strictEqual(mockFragments[1], actual, `expected sn ${mockFragments[1].sn}, but got sn ${actual ? actual.sn : null}`);
       assert(binarySearchSpy.notCalled);
     });
 
     it('uses BinarySearch to find a fragment if the subsequent one is not within tolerance', function () {
       const fragments = [mockFragments[0], mockFragments[(mockFragments.length - 1)]];
-      findFragmentBySN(fragments[0], fragments, bufferEnd, tolerance);
+      findFragmentByPTS(fragments[0], fragments, bufferEnd, tolerance);
       assert(binarySearchSpy.calledOnce);
     });
   });

--- a/tests/unit/controller/fragment-finders.js
+++ b/tests/unit/controller/fragment-finders.js
@@ -182,34 +182,34 @@ describe('Fragment finders', function () {
   describe('pdtWithinToleranceTest', function () {
     let tolerance = 0.25;
     let pdtBufferEnd = 1505502678523; // Fri Sep 15 2017 15:11:18 GMT-0400 (Eastern Daylight Time)
-    it('returns 0 if the fragment range is equal to the end of the buffer', function () {
+    it('returns true if the fragment range is equal to the end of the buffer', function () {
       const frag = {
         pdt: pdtBufferEnd,
         endPdt: pdtBufferEnd + 5000 - (tolerance * 1000),
         duration: 5
       };
       const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
-      assert.strictEqual(0, actual);
+      assert.strictEqual(true, actual);
     });
 
-    it('returns 1 if the fragment range is less than the end of the buffer', function () {
+    it('returns false if the fragment range is less than the end of the buffer', function () {
       const frag = {
         pdt: pdtBufferEnd - 10000,
         endPdt: pdtBufferEnd - 5000,
         duration: 5
       };
       const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
-      assert.strictEqual(1, actual);
+      assert.strictEqual(false, actual);
     });
 
-    it('returns -1 if the fragment range is greater than the end of the buffer', function () {
+    it('returns false if the fragment range is greater than the end of the buffer', function () {
       const frag = {
         pdt: pdtBufferEnd + 5000,
         endPdt: pdtBufferEnd + 10000,
         duration: 5
       };
       const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
-      assert.strictEqual(-1, actual);
+      assert.strictEqual(false, actual);
     });
 
     it('does not skip very small fragments', function () {
@@ -220,7 +220,7 @@ describe('Fragment finders', function () {
         deltaPTS: 0.1
       };
       const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
-      assert.strictEqual(0, actual);
+      assert.strictEqual(true, actual);
     });
 
     it('accounts for tolerance when checking the endPdt of the fragment', function () {
@@ -230,7 +230,7 @@ describe('Fragment finders', function () {
         duration: 5
       };
       const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
-      assert.strictEqual(1, actual);
+      assert.strictEqual(false, actual);
     });
 
     it('accounts for tolerance when checking the pdt of the fragment', function () {
@@ -240,7 +240,7 @@ describe('Fragment finders', function () {
         duration: 5
       };
       const actual = pdtWithinToleranceTest(pdtBufferEnd, tolerance, frag);
-      assert.strictEqual(0, actual);
+      assert.strictEqual(true, actual);
     });
   });
 });

--- a/tests/unit/controller/stream-controller.js
+++ b/tests/unit/controller/stream-controller.js
@@ -118,16 +118,16 @@ describe('StreamController tests', function () {
 
       let foundFragment = streamController._findFragment(0, fragPrevious, fragLen, mockFragments, bufferEnd, end, levelDetails);
       let resultSN = foundFragment ? foundFragment.sn : -1;
-      assert.equal(foundFragment, mockFragments[3], 'Expected sn 3, found sn segment ' + resultSN);
+      assert.equal(foundFragment, mockFragments[2], 'Expected sn 2, found sn segment ' + resultSN);
     });
 
     it('PDT search choosing fragment after starting/seeking to a new position (bufferEnd used)', function () {
       levelDetails.programDateTime = PDT;// If programDateTime contains a date then PDT is used
       let mediaSeekingTime = 17.00;
-
       let foundFragment = streamController._findFragment(0, null, fragLen, mockFragments, mediaSeekingTime, end, levelDetails);
       let resultSN = foundFragment ? foundFragment.sn : -1;
-      assert.equal(foundFragment, mockFragments[3], 'Expected sn 3, found sn segment ' + resultSN);
+      // Fragment 2 starts at 15:11:16 and ends at 15:11:21, which is the best candidate for buffering at the seeked-to PDT of 15:11:18
+      assert.equal(foundFragment, mockFragments[2], 'Expected sn 2, found sn segment ' + resultSN);
     });
 
     it('PDT serch hitting empty discontinuity', function () {
@@ -148,6 +148,11 @@ describe('StreamController tests', function () {
       const expected = fragments[2];
       const actual = streamController._findFragment(0, fragments[1], fragments.length, fragments, bufferEnd, end, levelDetails);
       assert.strictEqual(expected, actual);
+    });
+
+    it('returns the last fragment if the stream is fully buffered', function () {
+      const actual = streamController._findFragment(0, null, mockFragments.length, mockFragments, end, end, levelDetails);
+      assert.strictEqual(actual, mockFragments[mockFragments.length - 1]);
     });
   });
 });

--- a/tests/unit/controller/stream-controller.js
+++ b/tests/unit/controller/stream-controller.js
@@ -100,13 +100,13 @@ describe('StreamController tests', function () {
       levelDetails.hasProgramDateTime = false;
     });
 
-    it('SN search choosing wrong fragment (3 instead of 2) after level loaded', function () {
+    it('PTS search choosing wrong fragment (3 instead of 2) after level loaded', function () {
       let foundFragment = streamController._findFragment(0, fragPrevious, fragLen, mockFragments, bufferEnd, end, levelDetails);
       let resultSN = foundFragment ? foundFragment.sn : -1;
       assert.equal(foundFragment, mockFragments[3], 'Expected sn 3, found sn segment ' + resultSN);
     });
 
-    it('SN search choosing the right segment if fragPrevious is not available', function () {
+    it('PTS search choosing the right segment if fragPrevious is not available', function () {
       let foundFragment = streamController._findFragment(0, null, fragLen, mockFragments, bufferEnd, end, levelDetails);
       let resultSN = foundFragment ? foundFragment.sn : -1;
       assert.equal(foundFragment, mockFragments[3], 'Expected sn 2, found sn segment ' + resultSN);

--- a/tests/unit/loader/fragment.js
+++ b/tests/unit/loader/fragment.js
@@ -20,10 +20,10 @@ describe('Fragment class tests', function () {
       assert.strictEqual(frag.endPdt, 1000);
     });
 
-    it('returns 0 if pdt is NaN', function () {
+    it('returns null if pdt is NaN', function () {
       frag.pdt = 'foo';
       frag.duration = 1;
-      assert.strictEqual(frag.endPdt, 0);
+      assert.strictEqual(frag.endPdt, null);
     });
 
     it('defaults duration to 0 if duration is NaN', function () {

--- a/tests/unit/loader/fragment.js
+++ b/tests/unit/loader/fragment.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+import Fragment from '../../../src/loader/fragment';
+
+describe('Fragment class tests', function () {
+  let frag;
+  describe('endPdt getter', function () {
+    beforeEach(function () {
+      frag = new Fragment();
+    });
+
+    it('computes endPdt when pdt and duration are valid', function () {
+      frag.pdt = 1000;
+      frag.duration = 1;
+      assert.strictEqual(frag.endPdt, 2000);
+    });
+
+    it('considers 0 a valid pdt', function () {
+      frag.pdt = 0;
+      frag.duration = 1;
+      assert.strictEqual(frag.endPdt, 1000);
+    });
+
+    it('returns 0 if pdt is NaN', function () {
+      frag.pdt = 'foo';
+      frag.duration = 1;
+      assert.strictEqual(frag.endPdt, 0);
+    });
+
+    it('defaults duration to 0 if duration is NaN', function () {
+      frag.pdt = 1000;
+      frag.duration = 'foo';
+      assert.strictEqual(frag.endPdt, 1000);
+    });
+  });
+});

--- a/tests/unit/loader/level.js
+++ b/tests/unit/loader/level.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+import Level from '../../../src/loader/level';
+
+describe('Level Class tests', function () {
+  it('sets programDateTime to true when the first fragment has valid pdt', function () {
+    const level = new Level();
+    level.fragments = [{ pdt: 1 }];
+    assert.strictEqual(level.hasProgramDateTime, true);
+  });
+
+  it('sets programDateTime to false when no fragments is empty', function () {
+    const level = new Level();
+    assert.strictEqual(level.hasProgramDateTime, false);
+  });
+
+  it('sets programDateTime to false when the first fragment has an invalid pdt', function () {
+    const level = new Level();
+    level.fragments = [{ pdt: 'foo' }];
+    assert.strictEqual(level.hasProgramDateTime, false);
+  });
+});

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -655,7 +655,7 @@ main.mp4`;
     assert.strictEqual(result.initSegment.sn, 'initSegment');
   });
 
-  describe.only('PDT calculations', function () {
+  describe('PDT calculations', function () {
     it('if playlists contains #EXT-X-PROGRAM-DATE-TIME switching will be applied by PDT', () => {
       let level = `#EXTM3U
 #EXT-X-VERSION:2

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -770,17 +770,17 @@ frag1.ts
     });
 
     it('ignores bad PDT values', function () {
-        const level = `
+      const level = `
 #EXTINF:10
 #EXT-X-PROGRAM-DATE-TIME:foo
 frag0.ts
 #EXTINF:10
 frag1.ts
     `;
-        const result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
-        assert.strictEqual(result.hasProgramDateTime, false);
-        assert.strictEqual(result.fragments[0].rawProgramDateTime, undefined);
-        assert.strictEqual(result.fragments[0].pdt, undefined);
+      const result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
+      assert.strictEqual(result.hasProgramDateTime, false);
+      assert.strictEqual(result.fragments[0].rawProgramDateTime, undefined);
+      assert.strictEqual(result.fragments[0].pdt, undefined);
     });
   });
 });

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -617,11 +617,11 @@ Rollover38803/20160525T064049-01-69844069.ts
     assert.strictEqual(result.hasProgramDateTime, true);
     assert.strictEqual(result.totalduration, 30);
     assert.strictEqual(result.fragments[0].url, 'http://video.example.com/Rollover38803/20160525T064049-01-69844067.ts');
-    assert.strictEqual(result.fragments[0].programDateTime.getTime(), 1464366884000);
+    assert.strictEqual(result.fragments[0].pdt, 1464366884000);
     assert.strictEqual(result.fragments[1].url, 'http://video.example.com/Rollover38803/20160525T064049-01-69844068.ts');
-    assert.strictEqual(result.fragments[1].programDateTime.getTime(), 1464366894000);
+    assert.strictEqual(result.fragments[1].pdt, 1464366894000);
     assert.strictEqual(result.fragments[2].url, 'http://video.example.com/Rollover38803/20160525T064049-01-69844069.ts');
-    assert.strictEqual(result.fragments[2].programDateTime.getTime(), 1464366904000);
+    assert.strictEqual(result.fragments[2].pdt, 1464366904000);
   });
 
   it('parses #EXTINF without a leading digit', () => {
@@ -655,8 +655,9 @@ main.mp4`;
     assert.strictEqual(result.initSegment.sn, 'initSegment');
   });
 
-  it('if playlists contains #EXT-X-PROGRAM-DATE-TIME switching will be applied by PDT', () => {
-    let level = `#EXTM3U
+  describe.only('PDT calculations', function () {
+    it('if playlists contains #EXT-X-PROGRAM-DATE-TIME switching will be applied by PDT', () => {
+      let level = `#EXTM3U
 #EXT-X-VERSION:2
 #EXT-X-TARGETDURATION:10
 #EXT-X-MEDIA-SEQUENCE:69844067
@@ -670,24 +671,116 @@ Rollover38803/20160525T064049-01-69844068.ts
 #EXT-X-PROGRAM-DATE-TIME:2016-05-27T16:35:04Z
 Rollover38803/20160525T064049-01-69844069.ts
     `;
-    let result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
-    assert.ok(result.hasProgramDateTime);
-  });
+      let result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
+      assert.strictEqual(result.hasProgramDateTime, true);
+      assert.strictEqual(result.fragments[0].rawProgramDateTime, '2016-05-27T16:34:44Z');
+      assert.strictEqual(result.fragments[0].pdt, 1464366884000);
+      assert.strictEqual(result.fragments[1].rawProgramDateTime, '2016-05-27T16:34:54Z');
+      assert.strictEqual(result.fragments[1].pdt, 1464366894000);
+      assert.strictEqual(result.fragments[2].rawProgramDateTime, '2016-05-27T16:35:04Z');
+      assert.strictEqual(result.fragments[2].pdt, 1464366904000);
+    });
 
-  it('if playlists does NOT contain #EXT-X-PROGRAM-DATE-TIME switching will be applied by CC count', () => {
-    let level = `#EXTM3U
-#EXT-X-VERSION:2
-#EXT-X-TARGETDURATION:10
-#EXT-X-MEDIA-SEQUENCE:69844067
-#EXTINF:10, no desc
-Rollover38803/20160525T064049-01-69844067.ts
-#EXTINF:10, no desc
-Rollover38803/20160525T064049-01-69844068.ts
-#EXTINF:10, no desc
-Rollover38803/20160525T064049-01-69844069.ts
+    it('backfills PDT values if the first segment does not start with PDT', function () {
+      const level = `
+#EXTINF:10
+frag0.ts
+#EXTINF:10
+frag1.ts
+#EXTINF:10
+#EXT-X-PROGRAM-DATE-TIME:2016-05-27T16:35:04Z
+frag2.ts
     `;
-    let hls = { config: { }, on: function () { } };
-    let result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
-    assert.strictEqual(result.programDateTime, undefined);
+
+      const result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
+      assert.strictEqual(result.hasProgramDateTime, true);
+      assert.strictEqual(result.fragments[2].rawProgramDateTime, '2016-05-27T16:35:04Z');
+      assert.strictEqual(result.fragments[1].pdt, 1464366894000);
+      assert.strictEqual(result.fragments[0].pdt, 1464366884000);
+    });
+
+    it('extrapolates PDT forward when subsequent fragments do not have a raw programDateTime', function () {
+      const level = `
+#EXTINF:10
+#EXT-X-PROGRAM-DATE-TIME:2016-05-27T16:35:04Z
+frag0.ts
+#EXTINF:10
+frag1.ts
+#EXTINF:10
+frag2.ts
+    `;
+
+      const result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
+      assert.strictEqual(result.hasProgramDateTime, true);
+      assert.strictEqual(result.fragments[0].rawProgramDateTime, '2016-05-27T16:35:04Z');
+      assert.strictEqual(result.fragments[1].pdt, 1464366914000);
+      assert.strictEqual(result.fragments[2].pdt, 1464366924000);
+    });
+
+    it('recomputes PDT extrapolation whenever a new raw programDateTime is hit', function () {
+      const level = `
+#EXTM3U
+#EXT-X-DISCONTINUITY
+#EXT-X-PROGRAM-DATE-TIME:2016-05-27T16:35:04Z
+#EXTINF:10
+frag0.ts
+#EXTINF:10
+frag1.ts
+#EXT-X-DISCONTINUITY
+#EXT-X-PROGRAM-DATE-TIME:2017-05-27T16:35:04Z
+#EXTINF:10
+frag2.ts
+#EXTINF:10
+frag3.ts
+#EXT-X-DISCONTINUITY
+#EXT-X-PROGRAM-DATE-TIME:2015-05-27T11:42:03Z
+#EXTINF:10
+frag4.ts
+#EXTINF:10
+frag5.ts
+    `;
+
+      const result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
+      assert.strictEqual(result.hasProgramDateTime, true);
+      assert.strictEqual(result.fragments[0].pdt, 1464366904000);
+      assert.strictEqual(result.fragments[0].rawProgramDateTime, '2016-05-27T16:35:04Z');
+      assert.strictEqual(result.fragments[1].pdt, 1464366914000);
+      assert.strictEqual(result.fragments[2].pdt, 1495902904000);
+      assert.strictEqual(result.fragments[2].rawProgramDateTime, '2017-05-27T16:35:04Z');
+      assert.strictEqual(result.fragments[3].pdt, 1495902914000);
+      assert.strictEqual(result.fragments[4].pdt, 1432726923000);
+      assert.strictEqual(result.fragments[4].rawProgramDateTime, '2015-05-27T11:42:03Z');
+      assert.strictEqual(result.fragments[5].pdt, 1432726933000);
+    });
+
+    it('propagates the raw programDateTime to the fragment following the init segment', function () {
+      const level = `
+#EXTINF:10
+#EXT-X-PROGRAM-DATE-TIME:2016-05-27T16:35:04Z
+#EXT-X-MAP
+frag0.ts
+#EXTINF:10
+frag1.ts
+    `;
+      const result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
+      assert.strictEqual(result.hasProgramDateTime, true);
+      assert.strictEqual(result.sn === 'initSegment', false);
+      assert.strictEqual(result.fragments[0].rawProgramDateTime, '2016-05-27T16:35:04Z');
+      assert.strictEqual(result.fragments[0].pdt, 1464366904000);
+    });
+
+    it('ignores bad PDT values', function () {
+        const level = `
+#EXTINF:10
+#EXT-X-PROGRAM-DATE-TIME:foo
+frag0.ts
+#EXTINF:10
+frag1.ts
+    `;
+        const result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
+        assert.strictEqual(result.hasProgramDateTime, false);
+        assert.strictEqual(result.fragments[0].rawProgramDateTime, undefined);
+        assert.strictEqual(result.fragments[0].pdt, undefined);
+    });
   });
 });

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -779,8 +779,8 @@ frag1.ts
     `;
       const result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
       assert.strictEqual(result.hasProgramDateTime, false);
-      assert.strictEqual(result.fragments[0].rawProgramDateTime, undefined);
-      assert.strictEqual(result.fragments[0].pdt, undefined);
+      assert.strictEqual(result.fragments[0].rawProgramDateTime, null);
+      assert.strictEqual(result.fragments[0].pdt, null);
     });
   });
 });

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -614,7 +614,7 @@ Rollover38803/20160525T064049-01-69844069.ts
     `;
     let result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
     assert.strictEqual(result.fragments.length, 3);
-    assert.strictEqual(result.programDateTime.getTime(), 1464366884000);
+    assert.strictEqual(result.hasProgramDateTime, true);
     assert.strictEqual(result.totalduration, 30);
     assert.strictEqual(result.fragments[0].url, 'http://video.example.com/Rollover38803/20160525T064049-01-69844067.ts');
     assert.strictEqual(result.fragments[0].programDateTime.getTime(), 1464366884000);
@@ -670,9 +670,8 @@ Rollover38803/20160525T064049-01-69844068.ts
 #EXT-X-PROGRAM-DATE-TIME:2016-05-27T16:35:04Z
 Rollover38803/20160525T064049-01-69844069.ts
     `;
-    let hls = { config: { }, on: function () { } };
     let result = M3U8Parser.parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8', 0);
-    assert.ok(result.programDateTime);
+    assert.ok(result.hasProgramDateTime);
   });
 
   it('if playlists does NOT contain #EXT-X-PROGRAM-DATE-TIME switching will be applied by CC count', () => {

--- a/tests/unit/utils/discontinuities.js
+++ b/tests/unit/utils/discontinuities.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 
-import { shouldAlignOnDiscontinuities, findDiscontinuousReferenceFrag, adjustPts, alignDiscontinuities } from '../../../src/utils/discontinuities';
+import { shouldAlignOnDiscontinuities, findDiscontinuousReferenceFrag, adjustPts, alignDiscontinuities, alignPDT } from '../../../src/utils/discontinuities';
 
 const mockReferenceFrag = {
   start: 20,
@@ -70,18 +70,18 @@ describe('level-helper', function () {
   });
 
   it('adjusts level fragments without overlapping CC range but with programDateTime info', function () {
-    const lastFrag = { cc: 0 };
     const lastLevel = {
       details: {
         PTSKnown: true,
-        programDateTime: new Date('2017-08-28 00:00:00'),
+        hasProgramDateTime: true,
         fragments: [
           {
             start: 20,
             startPTS: 20,
             endPTS: 24,
             duration: 4,
-            cc: 0
+            cc: 0,
+            pdt: 1503892800000
           },
           {
             start: 24,
@@ -108,7 +108,8 @@ describe('level-helper', function () {
           startPTS: 0,
           endPTS: 4,
           duration: 4,
-          cc: 2
+          cc: 2,
+          pdt: 1503892850000
         },
         {
           start: 4,
@@ -126,9 +127,9 @@ describe('level-helper', function () {
         }
       ],
       PTSKnown: false,
-      programDateTime: new Date('2017-08-28 00:00:50'),
       startCC: 2,
-      endCC: 3
+      endCC: 3,
+      hasProgramDateTime: true
     };
 
     let detailsExpected = {
@@ -138,7 +139,8 @@ describe('level-helper', function () {
           startPTS: 70,
           endPTS: 74,
           duration: 4,
-          cc: 2
+          cc: 2,
+          pdt: 1503892850000
         },
         {
           start: 74,
@@ -156,11 +158,11 @@ describe('level-helper', function () {
         }
       ],
       PTSKnown: true,
-      programDateTime: new Date('2017-08-28 00:00:50'),
       startCC: 2,
-      endCC: 3
+      endCC: 3,
+      hasProgramDateTime: true
     };
-    alignDiscontinuities(lastFrag, lastLevel, details);
+    alignPDT(details, lastLevel.details);
     assert.deepEqual(detailsExpected, details);
   });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ const clone = (...args) => Object.assign({}, ...args);
 /* Allow to customise builds through env-vars */
 const env = process.env;
 
-const addSubtitleSupport = !!env.SUBTITLE || !!env.USE_SUBTITLES ;
+const addSubtitleSupport = !!env.SUBTITLE || !!env.USE_SUBTITLES;
 const addAltAudioSupport = !!env.ALT_AUDIO || !!env.USE_ALT_AUDIO;
 const addEMESupport = false;
 const runAnalyzer = !!env.ANALYZE;
@@ -30,18 +30,29 @@ const uglifyJsOptions = {
 const baseConfig = {
   entry: './src/hls.js',
   module: {
+    strictExportPresence: true,
     rules: [
       {
         test: /\.js$/,
         exclude: [
           path.resolve(__dirname, 'node_modules')
         ],
-        use: {
-          loader: 'babel-loader'
+        loader: 'babel-loader',
+        options: {
+          plugins: [
+            {
+              visitor: {
+                CallExpression: function (espath, file) {
+                  if (espath.get('callee').matchesPattern('Number.isFinite'))
+                    espath.node.callee = file.addImport(path.resolve('src/polyfills/number-isFinite'), 'isFiniteNumber');
+                }
+              }
+            }
+          ]
         }
       }
     ]
-  },
+  }
 };
 
 const demoConfig = clone(baseConfig, {
@@ -61,13 +72,13 @@ const demoConfig = clone(baseConfig, {
   devtool: 'source-map'
 });
 
-function getPluginsForConfig(type, minify = false) {
+function getPluginsForConfig (type, minify = false) {
   // common plugins.
 
   const defineConstants = getConstantsForConfig(type);
 
   console.log(
-    `Building <${ minify ? 'minified' : 'non-minified / debug' }> distro-type "${type}" with compile-time defined constants:`,
+    `Building <${minify ? 'minified' : 'non-minified / debug'}> distro-type "${type}" with compile-time defined constants:`,
     JSON.stringify(defineConstants, null, 4),
     '\n'
   );
@@ -95,13 +106,13 @@ function getPluginsForConfig(type, minify = false) {
     }));
   } else {
     // https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/115
-    plugins.push(new webpack.optimize.ModuleConcatenationPlugin())
+    plugins.push(new webpack.optimize.ModuleConcatenationPlugin());
   }
 
   return plugins;
 }
 
-function getConstantsForConfig(type) {
+function getConstantsForConfig (type) {
   // By default the "main" dists (hls.js & hls.min.js) are full-featured.
   return {
     __VERSION__: JSON.stringify(pkgJson.version),
@@ -111,7 +122,7 @@ function getConstantsForConfig(type) {
   };
 }
 
-function getAliasesForLightDist() {
+function getAliasesForLightDist () {
   let aliases = {};
 
   if (!addEMESupport) {
@@ -153,7 +164,7 @@ const multiConfig = [
       libraryExport: 'default'
     },
     plugins: getPluginsForConfig('main'),
-    devtool: 'source-map',
+    devtool: 'source-map'
   },
   {
     name: 'dist',


### PR DESCRIPTION
### This PR will...
- Stop searching for fragments via PDT when PTS is known
- Backfill PDT values in cases when the first PDT tag does not correspond to the first fragment
- Remove `programDateTime` property from `level.details`; PDT can change between discontinuities within a level. `hasProgramDateTime` has been added to `details` so that code can easily infer if PDT is available for use; if true, all fragments will have `pdt` set.
- Lazy compute `endPdt` since it changes based on duration; duration may change after frags are demuxed
- Avoid assigning pdt to the level or frag if it is NaN
- Apply search tolerances to finding frags via PDT 
- Clean up redundant code
- Add tests


### Why is this Pull Request needed?
- Searching for fragments via PDT when PTS is known is useless. When the PTS of each fragment is known, Hls.js knows which fragment to choose at any given time. PTS is more reliable and robust than PDT. PDT will now only be used for live streams when the PTS is unknown, which is typical when switching renditions.
- Backfilling PDT values is conformant to the spec. The original implementation was not correct.
- Without applying the tolerances small discrepancies in PDT cause fragments to loop load or be missed
- Bad PDT values (non-date, NaN) cause the wrong fragment to be selected.

### Are there any points in the code the reviewer needs to double check?
Sure. Any more unit tests to add?

### Resolves issues:
JW8-1706