### PR TITLE
Only compute PTS using timeoffset when the ID3 timestamp is NaN 

### DIFF
--- a/src/demux/aacdemuxer.js
+++ b/src/demux/aacdemuxer.js
@@ -45,7 +45,7 @@ class AACDemuxer {
     let track = this._audioTrack;
     let id3Data = ID3.getID3Data(data, 0) || [];
     let timestamp = ID3.getTimeStamp(id3Data);
-    let pts = timestamp ? 90 * timestamp : timeOffset * 90000;
+    let pts = isNaN(timestamp) ? timeOffset * 90000 : timestamp * 90;
     let frameIndex = 0;
     let stamp = pts;
     let length = data.length;


### PR DESCRIPTION
### Why is this Pull Request needed?
Our current code will compute an AAC timestamp based on the current stream time (timeoffset) if the ID3 timestamp is not found; we use a falsy check to verify this. However, the timestamp of a segment following a discontinuity may be 0. The timeoffset-computed timestamp will allow that segment to buffer, but will cause the remuxer to misscalculate the base PTS for the new discontinuous range. This miscalculation causes the remuxer to detect fragments subsequent to the first discontinuous fragment as overlapping.

This is what should happen:
10 -> 20 -> 30 -> **D** -> 0 -> 10

But this is what actually happens:
10 -> 20 -> 30 -> **D** -> 40 -> 10

### Are there any points in the code the reviewer needs to double check?
Is `isNaN` fine here? We aren't in danger of accidentally casting a string (and this tricking `isNaN`) but I know it's not the best practice. 

### Resolves issues:
JW8-1742