### PR TITLE
Clear 608 tracks on onSubtitleTracksCleared 

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -359,6 +359,7 @@ class TimelineController extends EventHandler {
 
   onSubtitleTracksCleared () {
     this.tracks = [];
+    this.captionsTracks = {};
   }
 
   onFragParsingUserdata (data) {


### PR DESCRIPTION
### Why is this Pull Request needed?
So that when a paused livestream is resumed, it re-emits the `NON_NATIVE_TEXT_TRACKS_FOUND` event; if tracks aren't cleared, they're re-used internally and not re-emitted. We clear the tracks in the tracks-mixin so we shouldn't reuse them anyway.

### Are there any points in the code the reviewer needs to double check?
Should I rename the `onSubtitleTracksCleared` event to `onTracksCleared` events to encompass subtitles and captions?

### Resolves issues:
JW8-1701


https://github.com/jwplayer/jwplayer-commercial/pull/5578