### PR TITLE
Use channel number over static field to determine captions channel

### DIFF
--- a/src/utils/cea-608-parser.js
+++ b/src/utils/cea-608-parser.js
@@ -856,7 +856,7 @@ class Cea608Parser {
         charsFound = this.parseChars(a, b);
         if (charsFound) {
           if (this.currChNr && this.currChNr >= 0) {
-            const channel = this.channels[field];
+            const channel = this.channels[this.currChNr];
             channel.insertChars(charsFound);
           } else {
             logger.log('WARNING', 'No channel found yet. TEXT-MODE?');


### PR DESCRIPTION
### This PR will...

This PR is designed to address the proper parsing of 608 Captions. Previously, the static field property was being used for channel assignment; this addresses this issue by using channel number to appropriately distribute the 608 channels.

### Why is this Pull Request needed?

Sinclair raised an issue in which both their English and Spanish 608 captions tracks were being parsed into the same channel. 

### Are there any points in the code the reviewer needs to double check?

N/A

### Resolves issues:

JW8-2264

### Checklist

- [Y] changes have been done against master branch, and PR does not conflict
- [N] new unit / functional tests have been added (whenever applicable) [Not applicable?]
- [N/A ] API or design changes are documented in API.md
