### PR TITLE
Avoid inserting 608 characters to a channel which does not match the current field

### DIFF
--- a/src/utils/cea-608-parser.js
+++ b/src/utils/cea-608-parser.js
@@ -886,8 +886,13 @@ class Cea608Parser {
         charsFound = this.parseChars(a, b);
         if (charsFound) {
           if (this.currChNr && this.currChNr >= 0) {
-            const channel = this.channels[this.currChNr];
-            channel.insertChars(charsFound);
+              if (field === 3 && this.currChNr > 2 || field === 1 && this.currChNr < 3) {
+                  const channel = this.channels[this.currChNr];
+                  channel.insertChars(charsFound);
+              } else {
+                  logger.log('WARNING', 'The last seen channel number does not fall within the current field. ' +
+                      'Deferring character insertion until the field and channel match.');
+              }
           } else {
             logger.log('WARNING', 'No channel found yet. TEXT-MODE?');
           }

--- a/src/utils/cea-608-parser.js
+++ b/src/utils/cea-608-parser.js
@@ -886,13 +886,13 @@ class Cea608Parser {
         charsFound = this.parseChars(a, b);
         if (charsFound) {
           if (this.currChNr && this.currChNr >= 0) {
-              if (field === 3 && this.currChNr > 2 || field === 1 && this.currChNr < 3) {
-                  const channel = this.channels[this.currChNr];
-                  channel.insertChars(charsFound);
-              } else {
-                  logger.log('WARNING', 'The last seen channel number does not fall within the current field. ' +
+            if (field === 3 && this.currChNr > 2 || field === 1 && this.currChNr < 3) {
+              const channel = this.channels[this.currChNr];
+              channel.insertChars(charsFound);
+            } else {
+              logger.log('WARNING', 'The last seen channel number does not fall within the current field. ' +
                       'Deferring character insertion until the field and channel match.');
-              }
+            }
           } else {
             logger.log('WARNING', 'No channel found yet. TEXT-MODE?');
           }


### PR DESCRIPTION
### Why is this Pull Request needed?
So that if a command to insert the characters into channel is received, but the last command set the channelNumber to a different field, those characters are not added to the wrong channel. 

The problem stems from the fact that our 608 parser is stateful. The channel to insert chars is determined by the previous command. If the previous command is to a different field (1 or 3) then the two captions fields get lumped together.

### Are there any points in the code the reviewer needs to double check?

No

### Resolves issues:
JW8-2264
