### PR TITLE
Only initial manifest parsing errors should be fatal

### DIFF
--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -425,9 +425,11 @@ class PlaylistLoader extends EventHandler {
     this.hls.trigger(Event.ERROR, {
       type: ErrorTypes.NETWORK_ERROR,
       details: ErrorDetails.MANIFEST_PARSING_ERROR,
-      fatal: true,
+      fatal: context.type === ContextType.MANIFEST,
       url: response.url,
       reason,
+      response,
+      context,
       networkDetails
     });
   }


### PR DESCRIPTION
### This PR will...
Make parsing errors on tracks and level responses non-fatal.

### Why is this Pull Request needed?
Network errors for tracks and level requests are not fatal. Parsing errors should be ignored so that content will play when a bad response is provided.

### Are there any points in the code the reviewer needs to double check?

- [x] TODO: Another PR that does make audio tracks / requests for EXT-X-MEDIA with no URI.
- Are there tests that cover this? I ran unit and functional tests and didn't see anything for the playlist-loader... Not adding new ones.
-  This could be considered a design change, but that depends on whether or not the `fatal` state of various errors is documented. I didn't come across anything when working on error handling.

### Resolves issues:
JW8-2274

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
