### PR TITLE
Avoid loading audio-track with undefined url

### DIFF
--- a/src/controller/audio-track-controller.js
+++ b/src/controller/audio-track-controller.js
@@ -323,13 +323,9 @@ class AudioTrackController extends TaskLoop {
    * @returns {boolean}
    */
   _needsTrackLoading (audioTrack) {
-    const { details } = audioTrack;
+    const { details, url } = audioTrack;
 
-    if (!details) {
-      return true;
-    } else if (details.live) {
-      return true;
-    }
+    return !!url && (!details || details.live === true);
   }
 
   /**


### PR DESCRIPTION
### This PR will...
Fix a regression that causes requests to be made for EXT-X-MEDIA tags with no URI. Initial fix: https://github.com/dailymotion/hls.js/commit/3f55cb658f2cef560ecb4b1f5f7e683e8666164a Regression: https://github.com/video-dev/hls.js/pull/1630/files#diff-1e463ee31dd666dbd318c50547c28613L130

### Why is this Pull Request needed?
It's valid to describe audio included in level renditions with an EXT-X-MEDIA tag that has no URI.

We've encountered uplynk HLS streams that include an EXT-X-MEDIA tag with no URI:
```
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="aac",NAME="unspecified",\
LANGUAGE="en",AUTOSELECT=YES,DEFAULT=YES
```

The spec says that this describes the audio in the rendition streams:
```
4.3.4.2.1.  Alternative Renditions
The URI attribute of the EXT-X-MEDIA tag is REQUIRED if the media
type is SUBTITLES, but OPTIONAL if the media type is VIDEO or AUDIO.
If the media type is VIDEO or AUDIO, a missing URI attribute
indicates that the media data for this Rendition is included in the
Media Playlist of any EXT-X-STREAM-INF tag referencing this
EXT-X-MEDIA tag.  If the media TYPE is AUDIO and the URI attribute is
missing, clients MUST assume that the audio data for this Rendition
is present in every video Rendition specified by the EXT-X-STREAM-INF
tag.
```
### Are there any points in the code the reviewer needs to double check?

I just added back the check for `url` that is required so that we don't make requests for audio tracks that are not considered `altAudio`.

I've added tests for audio-track-controller asserting that `AUDIO_TRACK_LOADING` is triggered for an initial track with a url, and not for an initial track without one. 

### Resolves issues:
JW8-2274

Upstream PR https://github.com/video-dev/hls.js/pull/1969

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] ~API or design changes are documented in API.md~