### PR TITLE
Bugfix/initial bw test

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -90,7 +90,7 @@ export var hlsDefaultConfig = {
   emeEnabled: false, // used by eme-controller
   widevineLicenseUrl: undefined, // used by eme-controller
   requestMediaKeySystemAccessFunc: requestMediaKeySystemAccess, // used by eme-controller
-  testBitrate: true
+  testBandwidth: true
 };
 
 if (__USE_SUBTITLES__) {

--- a/src/config.js
+++ b/src/config.js
@@ -89,8 +89,8 @@ export var hlsDefaultConfig = {
   minAutoBitrate: 0, // used by hls
   emeEnabled: false, // used by eme-controller
   widevineLicenseUrl: undefined, // used by eme-controller
-  requestMediaKeySystemAccessFunc:
-            requestMediaKeySystemAccess // used by eme-controller
+  requestMediaKeySystemAccessFunc: requestMediaKeySystemAccess, // used by eme-controller
+  testBitrate: true
 };
 
 if (__USE_SUBTITLES__) {

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -92,11 +92,11 @@ class StreamController extends TaskLoop {
           } else {
             startLevel = hls.nextAutoLevel;
           }
-          // set new level to playlist loader : this will trigger start level load
-          // hls.nextLoadLevel remains until it is set to a new value or until a new frag is successfully loaded
-          this.level = hls.nextLoadLevel = startLevel;
-          this.loadedmetadata = false;
         }
+        // set new level to playlist loader : this will trigger start level load
+        // hls.nextLoadLevel remains until it is set to a new value or until a new frag is successfully loaded
+        this.level = hls.nextLoadLevel = startLevel;
+        this.loadedmetadata = false;
       }
       // if startPosition undefined but lastCurrentTime set, set startPosition to last currentTime
       if (lastCurrentTime > 0 && startPosition === -1) {

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -76,7 +76,7 @@ class StreamController extends TaskLoop {
 
   startLoad (startPosition) {
     if (this.levels) {
-      let lastCurrentTime = this.lastCurrentTime, hls = this.hls;
+      const { lastCurrentTime, hls } = this;
       this.stopLoad();
       this.setInterval(100);
       this.level = -1;
@@ -85,14 +85,18 @@ class StreamController extends TaskLoop {
         // determine load level
         let startLevel = hls.startLevel;
         if (startLevel === -1) {
-          // -1 : guess start Level by doing a bitrate test by loading first fragment of lowest quality level
-          startLevel = 0;
-          this.bitrateTest = true;
+          if (hls.config.testBitrate) {
+            // -1 : guess start Level by doing a bitrate test by loading first fragment of lowest quality level
+            startLevel = 0;
+            this.bitrateTest = true;
+          } else {
+            startLevel = hls.nextAutoLevel;
+          }
+          // set new level to playlist loader : this will trigger start level load
+          // hls.nextLoadLevel remains until it is set to a new value or until a new frag is successfully loaded
+          this.level = hls.nextLoadLevel = startLevel;
+          this.loadedmetadata = false;
         }
-        // set new level to playlist loader : this will trigger start level load
-        // hls.nextLoadLevel remains until it is set to a new value or until a new frag is successfully loaded
-        this.level = hls.nextLoadLevel = startLevel;
-        this.loadedmetadata = false;
       }
       // if startPosition undefined but lastCurrentTime set, set startPosition to last currentTime
       if (lastCurrentTime > 0 && startPosition === -1) {

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -85,7 +85,7 @@ class StreamController extends TaskLoop {
         // determine load level
         let startLevel = hls.startLevel;
         if (startLevel === -1) {
-          if (hls.config.testBitrate) {
+          if (hls.config.testBandwidth) {
             // -1 : guess start Level by doing a bitrate test by loading first fragment of lowest quality level
             startLevel = 0;
             this.bitrateTest = true;


### PR DESCRIPTION
### This PR will...
- Create new `testBandwidth` config option
- Skips the bw test in `streamController` if `testBandwidth` is false
- Refactor some code in `abr-controller` (no functional changes)

### Why is this Pull Request needed?

So that we can avoid downloading an additional frag on startup when we provide a default bandwidth estimate.

### Are there any points in the code the reviewer needs to double check?
Do you think there's a better way to do this? I explored several solutions to signal that the bw test should not be performed, and found that a config option was the cleanest.

### Resolves issues:
JW8-1435
