### PR TITLE
Use PTS instead of DTS to adjust frag start/duration after muxing

### DIFF
--- a/src/controller/level-helper.js
+++ b/src/controller/level-helper.js
@@ -72,13 +72,14 @@ export function updateFragPTSDTS (details, frag, startPTS, endPTS, startDTS, end
     endDTS = Math.max(endDTS, frag.endDTS);
   }
 
-  const drift = startPTS - frag.start;
-  frag.start = frag.startPTS = startPTS;
+  const drift = startDTS - frag.start;
+  frag.start = startDTS;
+  frag.startPTS = startPTS;
   frag.maxStartPTS = maxStartPTS;
   frag.endPTS = endPTS;
   frag.startDTS = startDTS;
   frag.endDTS = endDTS;
-  frag.duration = endPTS - startPTS;
+  frag.duration = endDTS - startDTS;
 
   const sn = frag.sn;
   // exit if sn out of range

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -169,5 +169,9 @@ module.exports = {
   pdtOneValue: {
     url: 'https://playertest.longtailvideo.com/adaptive/aviion/manifest.m3u8',
     description: 'One PDT, no discontinuities'
+  },
+  differentPTSDTSWithSmallSubsequentSegment: {
+    url: 'https://9secfail-tepnrytnng.now.sh/index.m3u8',
+    description: 'First segment has a difference in PTS/DTS in both audio and video; the following segment is very small (0.04s)'
   }
 };


### PR DESCRIPTION
### Why is this Pull Request needed?
We're remuxing TS to FMP4 using DTS as the time offset in the case that PTS and DTS do not align. But when adjusting the data structure representing a segment (`details.fragments`), Hls.js uses PTS to adjust start time & duration. This causes an inconsistency between where Hls.js thinks a segment belongs, and where it will actually buffer in MSE. The consequence of this can be seen in the test stream - under normal circumstances this small discrepancy would be smoothed over when selecting the next segment, but if that segment is very small (`< 0.25s`), Hls.js fails to consider it suitable to buffer, and stalls.

https://9secfail-tepnrytnng.now.sh/index.m3u8

### Are there any points in the code the reviewer needs to double check?
Are there any streams which break because of this change?

### Resolves issues:

Upstream, but pulling it down here to run automation against it.