### PR TITLE
[WIP, writing tests] Improve behavior around buffer intersections

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -621,7 +621,6 @@ class AudioStreamController extends TaskLoop {
         this.state === State.PARSING) {
       const { audioSwitch, hls, media, pendingData, trackId } = this;
 
-      fragCurrent.addElementaryStream(Fragment.ElementaryStreamTypes.AUDIO);
       if (!Number.isFinite(data.endPTS)) {
         data.endPTS = data.startPTS + fragCurrent.duration;
         data.endDTS = data.startDTS + fragCurrent.duration;

--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -629,7 +629,7 @@ class AudioStreamController extends TaskLoop {
       logger.log(`parsed ${data.type},PTS:[${data.startPTS.toFixed(3)},${data.endPTS.toFixed(3)}],DTS:[${data.startDTS.toFixed(3)}/${data.endDTS.toFixed(3)}],nb:${data.nb}`);
 
       const track = this.tracks[trackId];
-      LevelHelper.updateFragPTSDTS(track.details, fragCurrent, data.startPTS, data.endPTS);
+      LevelHelper.updateFragPTSDTS(track.details, fragCurrent, data.startPTS, data.endPTS, data.type);
 
       let appendOnBufferFlush = false;
       // Only flush audio from old audio tracks when PTS is known on new audio track

--- a/src/controller/fragment-tracker.js
+++ b/src/controller/fragment-tracker.js
@@ -66,8 +66,8 @@ export class FragmentTracker extends EventHandler {
    * Partial fragments effected by coded frame eviction will be removed
    * The browser will unload parts of the buffer to free up memory for new buffer data
    * Fragments will need to be reloaded when the buffer is freed up, removing partial fragments will allow them to reload(since there might be parts that are still playable)
-   * @param {String} elementaryStream The elementaryStream of media this is (eg. video/audio)
-   * @param {TimeRanges} timeRange TimeRange object from a sourceBuffer
+   * @param {String} elementaryStream - The type of buffer to be searched (audio or video)
+   * @param {TimeRanges} timeRange - TimeRange object from a sourceBuffer
    */
   detectEvictedFragments (elementaryStream, timeRange) {
     // Check if any flagged fragments have been unloaded

--- a/src/controller/fragment-tracker.js
+++ b/src/controller/fragment-tracker.js
@@ -4,7 +4,6 @@ import Event from '../events';
 export const FragmentState = {
   NOT_LOADED: 'NOT_LOADED',
   APPENDING: 'APPENDING',
-  PARTIAL: 'PARTIAL',
   OK: 'OK'
 };
 
@@ -71,83 +70,17 @@ export class FragmentTracker extends EventHandler {
    * @param {TimeRanges} timeRange TimeRange object from a sourceBuffer
    */
   detectEvictedFragments (elementaryStream, timeRange) {
-    let fragmentTimes, time;
     // Check if any flagged fragments have been unloaded
     Object.keys(this.fragments).forEach(key => {
       const fragmentEntity = this.fragments[key];
       if (fragmentEntity.buffered === true) {
-        const esData = fragmentEntity.range[elementaryStream];
-        if (esData) {
-          fragmentTimes = esData.time;
-          for (let i = 0; i < fragmentTimes.length; i++) {
-            time = fragmentTimes[i];
-
-            if (this.isTimeBuffered(time.startPTS, time.endPTS, timeRange) === false) {
-              // Unregister partial fragment as it needs to load again to be reused
-              this.removeFragment(fragmentEntity.body);
-              break;
-            }
-          }
+        const timing = fragmentEntity.body.timing[elementaryStream];
+        if (!this.isTimeBuffered(timing.startPTS, timing.endPTS, timeRange)) {
+          // Unregister partial fragment as it needs to load again to be reused
+          this.removeFragment(fragmentEntity.body);
         }
       }
     });
-  }
-
-  /**
-   * Checks if the fragment passed in is loaded in the buffer properly
-   * Partially loaded fragments will be registered as a partial fragment
-   * @param {Object} fragment Check the fragment against all sourceBuffers loaded
-   */
-  detectPartialFragments (fragment) {
-    let fragKey = this.getFragmentKey(fragment);
-    let fragmentEntity = this.fragments[fragKey];
-    if (fragmentEntity) {
-      fragmentEntity.buffered = true;
-
-      Object.keys(this.timeRanges).forEach(elementaryStream => {
-        if (fragment.hasElementaryStream(elementaryStream)) {
-          let timeRange = this.timeRanges[elementaryStream];
-          // Check for malformed fragments
-          // Gaps need to be calculated for each elementaryStream
-          fragmentEntity.range[elementaryStream] = this.getBufferedTimes(fragment.startPTS, fragment.endPTS, timeRange);
-        }
-      });
-    }
-  }
-
-  getBufferedTimes (startPTS, endPTS, timeRange) {
-    let fragmentTimes = [];
-    let startTime, endTime;
-    let fragmentPartial = false;
-    for (let i = 0; i < timeRange.length; i++) {
-      startTime = timeRange.start(i) - this.bufferPadding;
-      endTime = timeRange.end(i) + this.bufferPadding;
-      if (startPTS >= startTime && endPTS <= endTime) {
-        // Fragment is entirely contained in buffer
-        // No need to check the other timeRange times since it's completely playable
-        fragmentTimes.push({
-          startPTS: Math.max(startPTS, timeRange.start(i)),
-          endPTS: Math.min(endPTS, timeRange.end(i))
-        });
-        break;
-      } else if (startPTS < endTime && endPTS > startTime) {
-        // Check for intersection with buffer
-        // Get playable sections of the fragment
-        fragmentTimes.push({
-          startPTS: Math.max(startPTS, timeRange.start(i)),
-          endPTS: Math.min(endPTS, timeRange.end(i))
-        });
-        fragmentPartial = true;
-      } else if (endPTS <= startTime) {
-        // No need to check the rest of the timeRange as it is in order
-        break;
-      }
-    }
-
-    return {
-      time: fragmentTimes,
-      partial: fragmentPartial
-    };
   }
 
   getFragmentKey (fragment) {
@@ -155,58 +88,23 @@ export class FragmentTracker extends EventHandler {
   }
 
   /**
-   * Gets the partial fragment for a certain time
-   * @param {Number} time
-   * @returns {Object} fragment Returns a partial fragment at a time or null if there is no partial fragment
-   */
-  getPartialFragment (time) {
-    let timePadding, startTime, endTime;
-    let bestFragment = null;
-    let bestOverlap = 0;
-    Object.keys(this.fragments).forEach(key => {
-      const fragmentEntity = this.fragments[key];
-      if (this.isPartial(fragmentEntity)) {
-        startTime = fragmentEntity.body.startPTS - this.bufferPadding;
-        endTime = fragmentEntity.body.endPTS + this.bufferPadding;
-        if (time >= startTime && time <= endTime) {
-          // Use the fragment that has the most padding from start and end time
-          timePadding = Math.min(time - startTime, endTime - time);
-          if (bestOverlap <= timePadding) {
-            bestFragment = fragmentEntity.body;
-            bestOverlap = timePadding;
-          }
-        }
-      }
-    });
-    return bestFragment;
-  }
-
-  /**
    * @param {Object} fragment The fragment to check
-   * @returns {String} Returns the fragment state when a fragment never loaded or if it partially loaded
+   * @returns {String} state The fragment state
    */
   getState (fragment) {
     let fragKey = this.getFragmentKey(fragment);
     let fragmentEntity = this.fragments[fragKey];
     let state = FragmentState.NOT_LOADED;
 
-    if (fragmentEntity !== undefined) {
+    if (fragmentEntity) {
       if (!fragmentEntity.buffered) {
         state = FragmentState.APPENDING;
-      } else if (this.isPartial(fragmentEntity) === true) {
-        state = FragmentState.PARTIAL;
       } else {
         state = FragmentState.OK;
       }
     }
 
     return state;
-  }
-
-  isPartial (fragmentEntity) {
-    return fragmentEntity.buffered === true &&
-      ((fragmentEntity.range.video !== undefined && fragmentEntity.range.video.partial === true) ||
-        (fragmentEntity.range.audio !== undefined && fragmentEntity.range.audio.partial === true));
   }
 
   isTimeBuffered (startPTS, endPTS, timeRange) {
@@ -237,7 +135,6 @@ export class FragmentTracker extends EventHandler {
     if (Number.isFinite(fragment.sn) && !fragment.bitrateTest) {
       this.fragments[this.getFragmentKey(fragment)] = {
         body: fragment,
-        range: Object.create(null),
         buffered: false
       };
     }
@@ -259,7 +156,10 @@ export class FragmentTracker extends EventHandler {
    * Fires after a fragment has been loaded into the source buffer
    */
   onFragBuffered (e) {
-    this.detectPartialFragments(e.frag);
+    const fragmentEntity = this.fragments[this.getFragmentKey(e.frag)];
+    if (fragmentEntity) {
+      fragmentEntity.buffered = true;
+    }
   }
 
   /**
@@ -269,7 +169,7 @@ export class FragmentTracker extends EventHandler {
    */
   hasFragment (fragment) {
     const fragKey = this.getFragmentKey(fragment);
-    return this.fragments[fragKey] !== undefined;
+    return !!this.fragments[fragKey];
   }
 
   /**

--- a/src/controller/level-helper.js
+++ b/src/controller/level-helper.js
@@ -225,10 +225,10 @@ export function mergeDetails (oldDetails, newDetails) {
   // if at least one fragment contains PTS info, recompute PTS information for all fragments
   if (PTSFrag) {
     const { audio, video } = PTSFrag.timing;
-    if (Object.keys(audio).length) {
+    if (Number.isFinite(audio.startPTS)) {
       updateFragPTSDTS(newDetails, PTSFrag, audio.startPTS, audio.endPTS, audio.startDTS, audio.endDTS, 'audio');
     }
-    if (Object.keys(video).length) {
+    if (Number.isFinite(video.startPTS)) {
       updateFragPTSDTS(newDetails, PTSFrag, video.startPTS, video.endPTS, video.startDTS, video.endDTS, 'video');
     }
   } else {

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -487,7 +487,7 @@ class StreamController extends TaskLoop {
     }
 
     // Allow backtracked fragments to load
-    if (frag.backtracked || fragState === FragmentState.NOT_LOADED || fragState === FragmentState.PARTIAL) {
+    if (frag.backtracked || fragState === FragmentState.NOT_LOADED) {
       frag.autoLevel = this.hls.autoLevelEnabled;
       frag.bitrateTest = this.bitrateTest;
 
@@ -1135,7 +1135,7 @@ class StreamController extends TaskLoop {
         }
       }
 
-      let drift = LevelHelper.updateFragPTSDTS(level.details, frag, data.startPTS, data.endPTS, data.startDTS, data.endDTS),
+      let drift = LevelHelper.updateFragPTSDTS(level.details, frag, data.startPTS, data.endPTS, data.startDTS, data.endDTS, data.type),
         hls = this.hls;
       hls.trigger(Event.LEVEL_PTS_UPDATED, { details: level.details, level: this.level, drift: drift, type: data.type, start: data.startPTS, end: data.endPTS });
       // has remuxer dropped video frames located before first keyframe ?
@@ -1229,6 +1229,7 @@ class StreamController extends TaskLoop {
         if (type === 'video') {
           this.videoBuffer = tracks[type].buffer;
         }
+        this.gapController.sourceBuffers[type] = tracks[type].buffer;
       } else {
         alternate = true;
       }

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1095,14 +1095,6 @@ class StreamController extends TaskLoop {
         data.endDTS = data.startDTS + fragCurrent.duration;
       }
 
-      if (data.hasAudio === true) {
-        frag.addElementaryStream(Fragment.ElementaryStreamTypes.AUDIO);
-      }
-
-      if (data.hasVideo === true) {
-        frag.addElementaryStream(Fragment.ElementaryStreamTypes.VIDEO);
-      }
-
       logger.log(`Parsed ${data.type},PTS:[${data.startPTS.toFixed(3)},${data.endPTS.toFixed(3)}],DTS:[${data.startDTS.toFixed(3)}/${data.endDTS.toFixed(3)}],nb:${data.nb},dropped:${data.dropped || 0}`);
 
       // Detect gaps in a fragment  and try to fix it by finding a keyframe in the previous fragment (see _findFragments)
@@ -1404,7 +1396,7 @@ class StreamController extends TaskLoop {
     const media = this.mediaBuffer ? this.mediaBuffer : this.media;
     if (media) {
       // filter fragments potentially evicted from buffer. this is to avoid memleak on live streams
-      this.fragmentTracker.detectEvictedFragments(Fragment.ElementaryStreamTypes.VIDEO, media.buffered);
+      this.fragmentTracker.detectEvictedFragments('video', media.buffered);
     }
     // move to IDLE once flush complete. this should trigger new fragment loading
     this.state = State.IDLE;

--- a/src/demux/demuxer.js
+++ b/src/demux/demuxer.js
@@ -95,7 +95,8 @@ class Demuxer {
 
   push (data, initSegment, audioCodec, videoCodec, frag, duration, accurateTimeOffset, defaultInitPTS) {
     const w = this.w;
-    const timeOffset = Number.isFinite(frag.startDTS) ? frag.startDTS : frag.start;
+    const videoStartDTS = frag.timing['video'] ? frag.timing['video'].startDTS : null;
+    const timeOffset = Number.isFinite(videoStartDTS) ? videoStartDTS : frag.start;
     const decryptdata = frag.decryptdata;
     const lastFrag = this.frag;
     const discontinuity = !(lastFrag && (frag.cc === lastFrag.cc));

--- a/src/loader/fragment.js
+++ b/src/loader/fragment.js
@@ -11,6 +11,13 @@ export default class Fragment {
     this.tagList = [];
     this.programDateTime = null;
     this.rawProgramDateTime = null;
+    this.timing = {
+      audio: {},
+      video: {}
+    };
+    this.estimatedStart = null;
+    this.estimatedEnd = null;
+    this.estimatedDuration = null;
 
     // Holds the types of data this fragment supports
     this._elementaryStreams = {

--- a/src/loader/fragment.js
+++ b/src/loader/fragment.js
@@ -15,27 +15,6 @@ export default class Fragment {
       audio: {},
       video: {}
     };
-    this.estimatedStart = null;
-    this.estimatedEnd = null;
-    this.estimatedDuration = null;
-
-    // Holds the types of data this fragment supports
-    this._elementaryStreams = {
-      [Fragment.ElementaryStreamTypes.AUDIO]: false,
-      [Fragment.ElementaryStreamTypes.VIDEO]: false
-    };
-  }
-
-  /**
-   * `type` property for this._elementaryStreams
-   *
-   * @enum
-   */
-  static get ElementaryStreamTypes () {
-    return {
-      AUDIO: 'audio',
-      VIDEO: 'video'
-    };
   }
 
   get url () {
@@ -105,20 +84,6 @@ export default class Fragment {
 
   get encrypted () {
     return !!((this.decryptdata && this.decryptdata.uri !== null) && (this.decryptdata.key === null));
-  }
-
-  /**
-   * @param {ElementaryStreamType} type
-   */
-  addElementaryStream (type) {
-    this._elementaryStreams[type] = true;
-  }
-
-  /**
-   * @param {ElementaryStreamType} type
-   */
-  hasElementaryStream (type) {
-    return this._elementaryStreams[type] === true;
   }
 
   /**

--- a/tests/unit/controller/fragment-tracker.js
+++ b/tests/unit/controller/fragment-tracker.js
@@ -14,10 +14,10 @@ function createMockBuffer (buffered) {
 }
 
 function createMockFragment (data, types) {
-  data._elementaryStreams = new Set(types);
-  data.hasElementaryStream = (type) => {
-    return data._elementaryStreams.has(type) === true;
-  };
+  data.timing = {};
+  types.forEach(t => {
+    data.timing[t] = {};
+  });
   return data;
 }
 

--- a/tests/unit/controller/gap-controller.js
+++ b/tests/unit/controller/gap-controller.js
@@ -92,20 +92,6 @@ describe('checkBuffer', function () {
       gapController._tryFixBufferStall(mockBufferInfo, mockStallDuration);
       expect(nudgeStub).to.have.not.been.called;
     });
-
-    it('should try to jump partial fragments when detected', function () {
-      sandbox.stub(gapController.fragmentTracker, 'getPartialFragment').returns({});
-      const skipHoleStub = sandbox.stub(gapController, '_trySkipBufferHole');
-      gapController._tryFixBufferStall({ len: 0 });
-      expect(skipHoleStub).to.have.been.calledOnce;
-    });
-
-    it('should not try to jump partial fragments when none are detected', function () {
-      sandbox.stub(gapController.fragmentTracker, 'getPartialFragment').returns(null);
-      const skipHoleStub = sandbox.stub(gapController, '_trySkipBufferHole');
-      gapController._tryFixBufferStall({ len: 0 });
-      expect(skipHoleStub).to.have.not.been.called;
-    });
   });
 
   describe('poll', function () {

--- a/tests/unit/controller/level-helper.js
+++ b/tests/unit/controller/level-helper.js
@@ -9,7 +9,8 @@ describe('level-helper', function () {
         fragments: []
       };
       frag = {
-        sn: 0
+        sn: 0,
+        timing: {}
       };
     });
 
@@ -30,7 +31,7 @@ describe('level-helper', function () {
         const startDTS = 1;
         const endDTS = 11;
 
-        LevelHelper.updateFragPTSDTS(null, frag, startPTS, endPTS, startDTS, endDTS);
+        LevelHelper.updateFragPTSDTS(null, frag, startPTS, endPTS, startDTS, endDTS, 'video');
         checkFragProperties(frag, 2, 12, 1, 11, 2);
       });
 
@@ -45,7 +46,7 @@ describe('level-helper', function () {
         frag.startDTS = 2;
         frag.endDTS = 12;
 
-        LevelHelper.updateFragPTSDTS(null, frag, startPTS, endPTS, startDTS, endDTS);
+        LevelHelper.updateFragPTSDTS(null, frag, startPTS, endPTS, startDTS, endDTS, 'video');
         checkFragProperties(frag, 3, 12, 2, 11, 3);
         expect(frag.deltaPTS).to.equal(1);
 
@@ -54,7 +55,7 @@ describe('level-helper', function () {
         frag.startDTS = 0;
         frag.endDTS = 10;
 
-        LevelHelper.updateFragPTSDTS(null, frag, startPTS, endPTS, startDTS, endDTS);
+        LevelHelper.updateFragPTSDTS(null, frag, startPTS, endPTS, startDTS, endDTS, 'video');
         checkFragProperties(frag, 2, 10, 1, 10, 2);
         expect(frag.deltaPTS).to.equal(2);
       });
@@ -70,7 +71,7 @@ describe('level-helper', function () {
         frag.startDTS = 2;
         frag.endDTS = 12;
 
-        LevelHelper.updateFragPTSDTS(null, frag, startPTS, endPTS, startDTS, endDTS);
+        LevelHelper.updateFragPTSDTS(null, frag, startPTS, endPTS, startDTS, endDTS, 'video');
         checkFragProperties(frag, 3, 24, 1, 12, 14);
         expect(frag.deltaPTS).to.equal(11);
       });
@@ -90,7 +91,7 @@ describe('level-helper', function () {
         details.live = false;
         frag.sn = 5;
 
-        LevelHelper.updateFragPTSDTS(details, frag, startPTS, endPTS, startDTS, endDTS);
+        LevelHelper.updateFragPTSDTS(details, frag, startPTS, endPTS, startDTS, endDTS, 'video');
         checkFragProperties(frag, 3, 13, 2, 12, 3);
         expect(frag.deltaPTS).to.equal(1);
       });

--- a/tests/unit/controller/stream-controller.js
+++ b/tests/unit/controller/stream-controller.js
@@ -171,12 +171,6 @@ describe('StreamController', function () {
       assertLoadingState(frag);
     });
 
-    it('should load a partial fragment', function () {
-      fragStateStub(FragmentState.PARTIAL);
-      streamController._loadFragment(frag);
-      assertLoadingState(frag);
-    });
-
     it('should load a frag which has backtracked', function () {
       fragStateStub(FragmentState.OK);
       frag.backtracked = true;

--- a/tests/unit/demuxer/demuxer.js
+++ b/tests/unit/demuxer/demuxer.js
@@ -78,7 +78,8 @@ describe('Demuxer tests', function () {
     let currentFrag = {
       cc: 100,
       sn: 5,
-      level: 1
+      level: 1,
+      timing: {}
     };
     // Config for push
     demux.frag = currentFrag;
@@ -88,8 +89,10 @@ describe('Demuxer tests', function () {
       cc: 100,
       sn: 6,
       level: 1,
-      startDTS: 1000,
-      start: undefined
+      start: undefined,
+      timing: {
+        video: { startDTS: 1000 }
+      }
     };
     let data = new ArrayBuffer(8),
       initSegment = {},
@@ -106,7 +109,7 @@ describe('Demuxer tests', function () {
       expect(obj1.initSegment).to.equal(initSegment, 'initSegment');
       expect(obj1.audioCodec).to.equal(audioCodec, 'audioCodec');
       expect(obj1.videoCodec).to.equal(videoCodec, 'videoCodec');
-      expect(obj1.timeOffset).to.equal(newFrag.startDTS, 'timeOffset');
+      expect(obj1.timeOffset).to.equal(newFrag.timing.video.startDTS, 'timeOffset');
       expect(obj1.discontinuity).to.be.false;
       expect(obj1.trackSwitch).to.be.false;
       expect(obj1.contiguous).to.be.true;
@@ -131,7 +134,8 @@ describe('Demuxer tests', function () {
     let currentFrag = {
       cc: 100,
       sn: 5,
-      level: 1
+      level: 1,
+      timing: {}
     };
     // Config for push
     demux.frag = currentFrag;
@@ -142,7 +146,8 @@ describe('Demuxer tests', function () {
       sn: 5,
       level: 2,
       startDTS: undefined,
-      start: 1000
+      start: 1000,
+      timing: {}
     };
     let data = {},
       initSegment = {},


### PR DESCRIPTION
### This PR will...
- Add raw PTS/DTS timing values to each fragment after muxing
- Propagate PTS/DTS timing values to unmuxed frags via updateFragPTSDTS
- Initialize the demuxer with the video track`startDTS` instead of the minimum of audio/video startDTS
- Remove partial fragment detection
- Jump gaps when stuck in non-intersecting ranges

### Why is this Pull Request needed?

- Preserving the raw PTS/DTS timing values is helpful in the scenario when we need timing for a _specific_ track. In `updateFragPTSDTS` we take the intersection of the audio/video timings; however, this removes their association with the corresponding track. This association is important when we need a specific value, as seen in the demuxer initialization. The demuxer uses video `_initDTS` as a reference internally, and in some cases providing the audio `initDTS` causes video frames to be dropped. https://playertest.longtailvideo.com/adaptive/boxee/playlist.m3u8 is an example of this.

- Partial fragment detection is not necessary now that we are calculating frag timing using intersections. With our previous calculations (using min start/max end), our predicted fragment timings would sometimes greatly differ between their reported buffer range. As far as I can understand the partial fragment system was designed to detect this kind of discrepancy, and flag fragments so that their gaps may easily be jumped. In our new system fragments will always match (or exceed, because of further intersections) their predicted times, and nothing was being flagged as partial.

- Since we're no longer flagging fragments as partial, our partial gap-jumping logic no longer works. I considered reworking partial detection to instead flag segments which have large gaps between their audio/video tracks. However, this seemed more complicated than just checking the XOR of the the sourceBuffers to see if we're stuck within a partial range.

For example:
```
(0, 5)(5, 10) audio
(3, 8)(8, 13) video
(3, 5)(8, 10) actual
```

In this case, we've buffered two fragments. The first has a large difference between audio/video, which results in a gap. The second does not. If we seek into the unbuffered range (for example, at time=6), Hls.js will get stuck. By checking the XOR of the range, we can know if a fragment has buffered there already, and if it has left a gap. It's important to know if we've already tried to buffer a fragment there because it could be network delay causing the gap, in which case we do not want to jump.

### Are there any points in the code the reviewer needs to double check?
Should partial frag detection be kept in the case that MSE doesn't buffer them the way we think they will be? Since we make the .fmp4 we know it's exact start/end PTS; but I'm not sure if there's a case where it doesn't buffer exactly as we make it. 

### Resolves issues:
Regressions related to:

https://9secfail-tepnrytnng.now.sh/index.m3u8

https://s3.amazonaws.com/bob.jwplayer.com/%7Ealex/123633/new_master.m3u8

https://playertest.longtailvideo.com/adaptive/boxee/playlist.m3u8
