### PR TITLE
Buffer streams starting at 0 initPTS

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1374,12 +1374,6 @@ class StreamController extends TaskLoop {
 
     if (!this.loadedmetadata && buffered.length) {
       this.loadedmetadata = true;
-      // Need to check what the SourceBuffer reports as start time for the first fragment appended.
-      // If within the threshold of maxBufferHole, adjust this.startPosition for _seekToStartPos().
-      var firstbufferedPosition = buffered.start(0);
-      if (Math.abs(this.startPosition - firstbufferedPosition) < this.config.maxBufferHole) {
-        this.startPosition = firstbufferedPosition;
-      }
       this._seekToStartPos();
     } else if (this.immediateSwitch) {
       this.immediateLevelSwitchEnd();

--- a/src/demux/demuxer.js
+++ b/src/demux/demuxer.js
@@ -95,7 +95,7 @@ class Demuxer {
 
   push (data, initSegment, audioCodec, videoCodec, frag, duration, accurateTimeOffset, defaultInitPTS) {
     const w = this.w;
-    const timeOffset = Number.isFinite(frag.startDTS) ? frag.startDTS : frag.start;
+    const timeOffset = Number.isFinite(frag.startPTS) ? frag.startPTS : frag.start;
     const decryptdata = frag.decryptdata;
     const lastFrag = this.frag;
     const discontinuity = !(lastFrag && (frag.cc === lastFrag.cc));

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -425,14 +425,14 @@ class MP4Remuxer {
   }
 
   remuxAudio (track, timeOffset, contiguous, accurateTimeOffset) {
-      const inputTimeScale = track.inputTimeScale;
-      const mp4timeScale = track.timescale;
-      const scaleFactor = inputTimeScale / mp4timeScale;
-      const mp4SampleDuration = track.isAAC ? 1024 : 1152;
-      const inputSampleDuration = mp4SampleDuration * scaleFactor;
-      const ptsNormalize = this._PTSNormalize;
-      const initPTS = this._initPTS;
-      const rawMPEG = !track.isAAC && this.typeSupported.mpeg;
+    const inputTimeScale = track.inputTimeScale;
+    const mp4timeScale = track.timescale;
+    const scaleFactor = inputTimeScale / mp4timeScale;
+    const mp4SampleDuration = track.isAAC ? 1024 : 1152;
+    const inputSampleDuration = mp4SampleDuration * scaleFactor;
+    const ptsNormalize = this._PTSNormalize;
+    const initPTS = this._initPTS;
+    const rawMPEG = !track.isAAC && this.typeSupported.mpeg;
 
     let offset,
       mp4Sample,

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -181,34 +181,19 @@ class MP4Remuxer {
 
   remuxVideo (track, timeOffset, contiguous, audioTrackLength, accurateTimeOffset) {
     let offset = 8;
-    const timeScale = track.timescale;
     let mp4SampleDuration;
     let mdat;
     let moof;
     let firstPTS;
     let firstDTS;
-    let nextDTS;
     let lastPTS;
     let lastDTS;
+    const timeScale = track.timescale;
     const inputSamples = track.samples;
     const outputSamples = [];
     const nbSamples = inputSamples.length;
     const ptsNormalize = this._PTSNormalize;
-    const initDTS = this._initDTS;
     const initPTS = this._initPTS;
-
-    // for (let i = 0; i < track.samples.length; i++) {
-    //   let avcSample = track.samples[i];
-    //   let units = avcSample.units;
-    //   let unitsString = '';
-    //   for (let j = 0; j < units.length ; j++) {
-    //     unitsString += units[j].type + ',';
-    //     if (units[j].data.length < 500) {
-    //       unitsString += Hex.hexDump(units[j].data);
-    //     }
-    //   }
-    //   logger.log(avcSample.pts + '/' + avcSample.dts + ',' + unitsString + avcSample.units.length);
-    // }
 
     // if parsed fragment is contiguous with last one, let's use last DTS value as reference
     let nextAvcDts = this.nextAvcDts;
@@ -228,7 +213,7 @@ class MP4Remuxer {
       //  - less than 200 ms PTS gaps (timeScale/5)
       contiguous |= (inputSamples.length && nextAvcDts &&
                      ((accurateTimeOffset && Math.abs(timeOffset - nextAvcDts / timeScale) < 0.1) ||
-                      Math.abs((inputSamples[0].pts - nextAvcDts - initDTS)) < timeScale / 5)
+                      Math.abs((inputSamples[0].pts - nextAvcDts - initPTS)) < timeScale / 5)
       );
     }
 
@@ -285,7 +270,6 @@ class MP4Remuxer {
         logger.log(`Video/PTS/DTS adjusted: ${Math.round(firstPTS / 90)}/${Math.round(firstDTS / 90)},delta:${delta} ms`);
       }
     }
-    nextDTS = firstDTS;
 
     // compute lastPTS/lastDTS
     sample = inputSamples[inputSamples.length - 1];
@@ -441,14 +425,14 @@ class MP4Remuxer {
   }
 
   remuxAudio (track, timeOffset, contiguous, accurateTimeOffset) {
-    const inputTimeScale = track.inputTimeScale,
-      mp4timeScale = track.timescale,
-      scaleFactor = inputTimeScale / mp4timeScale,
-      mp4SampleDuration = track.isAAC ? 1024 : 1152,
-      inputSampleDuration = mp4SampleDuration * scaleFactor,
-      ptsNormalize = this._PTSNormalize,
-      initDTS = this._initDTS,
-      rawMPEG = !track.isAAC && this.typeSupported.mpeg;
+      const inputTimeScale = track.inputTimeScale;
+      const mp4timeScale = track.timescale;
+      const scaleFactor = inputTimeScale / mp4timeScale;
+      const mp4SampleDuration = track.isAAC ? 1024 : 1152;
+      const inputSampleDuration = mp4SampleDuration * scaleFactor;
+      const ptsNormalize = this._PTSNormalize;
+      const initPTS = this._initPTS;
+      const rawMPEG = !track.isAAC && this.typeSupported.mpeg;
 
     let offset,
       mp4Sample,
@@ -469,12 +453,12 @@ class MP4Remuxer {
     // and this also avoids audio glitches/cut when switching quality, or reporting wrong duration on first audio frame
     contiguous |= (inputSamples.length && nextAudioPts &&
                    ((accurateTimeOffset && Math.abs(timeOffset - nextAudioPts / inputTimeScale) < 0.1) ||
-                    Math.abs((inputSamples[0].pts - nextAudioPts - initDTS)) < 20 * inputSampleDuration)
+                    Math.abs((inputSamples[0].pts - nextAudioPts - initPTS)) < 20 * inputSampleDuration)
     );
 
     // compute normalized PTS
     inputSamples.forEach(function (sample) {
-      sample.pts = sample.dts = ptsNormalize(sample.pts - initDTS, timeOffset * inputTimeScale);
+      sample.pts = sample.dts = ptsNormalize(sample.pts - initPTS, timeOffset * inputTimeScale);
     });
 
     // filter out sample with negative PTS that are not playable anyway
@@ -738,7 +722,7 @@ class MP4Remuxer {
     this.remuxAudio(track, timeOffset, contiguous);
   }
 
-  remuxID3 (track, timeOffset) {
+  remuxID3 (track) {
     let length = track.samples.length, sample;
     const inputTimeScale = track.inputTimeScale;
     const initPTS = this._initPTS;
@@ -758,10 +742,9 @@ class MP4Remuxer {
     }
 
     track.samples = [];
-    timeOffset = timeOffset;
   }
 
-  remuxText (track, timeOffset) {
+  remuxText (track) {
     track.samples.sort(function (a, b) {
       return (a.pts - b.pts);
     });
@@ -783,7 +766,6 @@ class MP4Remuxer {
     }
 
     track.samples = [];
-    timeOffset = timeOffset;
   }
 
   _PTSNormalize (value, reference) {

--- a/tests/unit/controller/stream-controller.js
+++ b/tests/unit/controller/stream-controller.js
@@ -246,15 +246,6 @@ describe('StreamController', function () {
       expect(streamController.loadedmetadata).to.not.exist;
     });
 
-    it('should set startPosition to what buffer start reports and seek', function () {
-      const seekStub = sandbox.stub(streamController, '_seekToStartPos');
-      streamController.startPosition = 6;
-      streamController.loadedmetadata = false;
-      streamController._checkBuffer();
-      expect(seekStub).to.have.been.calledOnce;
-      expect(streamController.startPosition).to.equal(streamController.media.buffered.start());
-    });
-
     it('should complete the immediate switch if signalled', function () {
       const levelSwitchStub = sandbox.stub(streamController, 'immediateLevelSwitchEnd');
       streamController.loadedmetadata = true;

--- a/tests/unit/demuxer/demuxer.js
+++ b/tests/unit/demuxer/demuxer.js
@@ -89,6 +89,7 @@ describe('Demuxer tests', function () {
       sn: 6,
       level: 1,
       startDTS: 1000,
+      startPTS: 1000,
       start: undefined
     };
     let data = new ArrayBuffer(8),


### PR DESCRIPTION
### This PR will...
Begin buffering streams at 0. Since we append to the buffer based on PTS, the initial startPTS should be 0.

### Why is this Pull Request needed?
So that we do not introduce gaps at the start of the video buffer or misalign audio and video based on DTS offsets.
