### PR TITLE
Initialize vttCCs map with cc 0

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -218,7 +218,8 @@ class TimelineController extends EventHandler {
       presentationOffset: 0,
       0: {
           start: 0, prevCC: -1, new: false,
-      }};
+      }
+    };
     this._cleanTracks();
   }
 

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -213,11 +213,14 @@ class TimelineController extends EventHandler {
   onManifestLoading () {
     this.lastSn = -1; // Detect discontiguity in fragment parsing
     this.prevCC = -1;
-    this.vttCCs = { // Detect discontinuity in subtitle manifests
+    // Detect discontinuity in subtitle manifests
+    // The start time for cc 0 is always 0; initialize it here first so that we don't accidentally set to the currentTime
+    // when captions are enabled.
+    this.vttCCs = {
       ccOffset: 0,
       presentationOffset: 0,
       0: {
-          start: 0, prevCC: -1, new: false,
+          start: 0, prevCC: -1, new: false
       }
     };
     this._cleanTracks();

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -213,7 +213,12 @@ class TimelineController extends EventHandler {
   onManifestLoading () {
     this.lastSn = -1; // Detect discontiguity in fragment parsing
     this.prevCC = -1;
-    this.vttCCs = { ccOffset: 0, presentationOffset: 0 }; // Detect discontinuity in subtitle manifests
+    this.vttCCs = { // Detect discontinuity in subtitle manifests
+      ccOffset: 0,
+      presentationOffset: 0,
+      0: {
+          start: 0, prevCC: -1, new: false,
+      }};
     this._cleanTracks();
   }
 

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -220,7 +220,7 @@ class TimelineController extends EventHandler {
       ccOffset: 0,
       presentationOffset: 0,
       0: {
-          start: 0, prevCC: -1, new: false
+        start: 0, prevCC: -1, new: false
       }
     };
     this._cleanTracks();


### PR DESCRIPTION
### Why is this Pull Request needed?
In a stream with no discontinuities, the `vttCCs` array for `cc 0` is not created until the time subtitles are enabled. This causes `vttCCs[0].start` to be set to the current time, which causes cue times to be doubled; the start for `cc 0` is always 0 and not the cue's start time. Therefore we should initialize this property to 0 from the start.

### Are there any points in the code the reviewer needs to double check?
Kind of hacky, but I think it's fine for a hotfix.

### Resolves issues:
#2046
