### PR TITLE
[JW8-2659] Implement live VTT subtitle loading

### DIFF
--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -46,17 +46,6 @@ class AudioStreamController extends BaseStreamController {
     this.videoTrackCC = null;
   }
 
-  onHandlerDestroying () {
-    this.stopLoad();
-    super.onHandlerDestroying();
-  }
-
-  onHandlerDestroyed () {
-    this.state = State.STOPPED;
-    this.fragmentTracker = null;
-    super.onHandlerDestroyed();
-  }
-
   // Signal that video PTS was found
   onInitPtsFound (data) {
     let demuxerId = data.id, cc = data.frag.cc, initPTS = data.initPTS;
@@ -94,24 +83,6 @@ class AudioStreamController extends BaseStreamController {
       this.startPosition = startPosition;
       this.state = State.STOPPED;
     }
-  }
-
-  stopLoad () {
-    let frag = this.fragCurrent;
-    if (frag) {
-      if (frag.loader) {
-        frag.loader.abort();
-      }
-
-      this.fragmentTracker.removeFragment(frag);
-      this.fragCurrent = null;
-    }
-    this.fragPrevious = null;
-    if (this.demuxer) {
-      this.demuxer.destroy();
-      this.demuxer = null;
-    }
-    this.state = State.STOPPED;
   }
 
   set state (nextState) {

--- a/src/controller/base-stream-controller.js
+++ b/src/controller/base-stream-controller.js
@@ -24,6 +24,26 @@ export const State = {
 export default class BaseStreamController extends TaskLoop {
   doTick () {}
 
+  startLoad () {}
+
+  stopLoad () {
+    let frag = this.fragCurrent;
+    if (frag) {
+      if (frag.loader) {
+        frag.loader.abort();
+      }
+      this.fragmentTracker.removeFragment(frag);
+    }
+    if (this.demuxer) {
+      this.demuxer.destroy();
+      this.demuxer = null;
+    }
+    this.fragCurrent = null;
+    this.fragPrevious = null;
+    this.clearInterval();
+    this.state = State.STOPPED;
+  }
+
   _streamEnded (bufferInfo, levelDetails) {
     const { fragCurrent, fragmentTracker } = this;
     // we just got done loading the final fragment and there is no other buffered range after ...
@@ -93,5 +113,16 @@ export default class BaseStreamController extends TaskLoop {
   onMediaEnded () {
     // reset startPosition and lastCurrentTime to restart playback @ stream beginning
     this.startPosition = this.lastCurrentTime = 0;
+  }
+
+  onHandlerDestroying () {
+    this.stopLoad();
+    super.onHandlerDestroying();
+  }
+
+  onHandlerDestroyed () {
+    this.state = State.STOPPED;
+    this.fragmentTracker = null;
+    super.onHandlerDestroyed();
   }
 }

--- a/src/controller/base-stream-controller.js
+++ b/src/controller/base-stream-controller.js
@@ -41,6 +41,7 @@ export default class BaseStreamController extends TaskLoop {
     this.fragCurrent = null;
     this.fragPrevious = null;
     this.clearInterval();
+    this.clearNextTick();
     this.state = State.STOPPED;
   }
 
@@ -123,6 +124,5 @@ export default class BaseStreamController extends TaskLoop {
   onHandlerDestroyed () {
     this.state = State.STOPPED;
     this.fragmentTracker = null;
-    super.onHandlerDestroyed();
   }
 }

--- a/src/controller/fragment-tracker.js
+++ b/src/controller/fragment-tracker.js
@@ -234,13 +234,15 @@ export class FragmentTracker extends EventHandler {
     const fragment = e.frag;
     // don't track initsegment (for which sn is not a number)
     // don't track frags used for bitrateTest, they're irrelevant.
-    if (Number.isFinite(fragment.sn) && !fragment.bitrateTest) {
-      this.fragments[this.getFragmentKey(fragment)] = {
-        body: fragment,
-        range: Object.create(null),
-        buffered: false
-      };
+    if (!Number.isFinite(fragment.sn) || fragment.bitrateTest || fragment.type === 'subtitle') {
+      return;
     }
+
+    this.fragments[this.getFragmentKey(fragment)] = {
+      body: fragment,
+      range: Object.create(null),
+      buffered: false
+    };
   }
 
   /**

--- a/src/controller/fragment-tracker.js
+++ b/src/controller/fragment-tracker.js
@@ -234,7 +234,7 @@ export class FragmentTracker extends EventHandler {
     const fragment = e.frag;
     // don't track initsegment (for which sn is not a number)
     // don't track frags used for bitrateTest, they're irrelevant.
-    if (!Number.isFinite(fragment.sn) || fragment.bitrateTest || fragment.type === 'subtitle') {
+    if (!Number.isFinite(fragment.sn) || fragment.bitrateTest) {
       return;
     }
 

--- a/src/controller/level-helper.js
+++ b/src/controller/level-helper.js
@@ -213,17 +213,17 @@ export function adjustSliding (oldPlaylist, newPlaylist) {
 
 export function computeReloadInterval (currentPlaylist, newPlaylist, lastRequestTime) {
   let reloadInterval = 1000 * (newPlaylist.averagetargetduration ? newPlaylist.averagetargetduration : newPlaylist.targetduration);
+  const minReloadInterval = reloadInterval / 2;
   if (currentPlaylist && newPlaylist.endSN === currentPlaylist.endSN) {
     // follow HLS Spec, If the client reloads a Playlist file and finds that it has not
     // changed then it MUST wait for a period of one-half the target
     // duration before retrying.
-    reloadInterval /= 2;
+    reloadInterval = minReloadInterval;
   }
-  // decrement reloadInterval with level loading delay
+
   if (lastRequestTime) {
-    reloadInterval -= (window.performance.now() - lastRequestTime);
+    reloadInterval = Math.max(minReloadInterval, reloadInterval - (window.performance.now() - lastRequestTime));
   }
   // in any case, don't reload more than half of target duration
-  reloadInterval = Math.max(reloadInterval / 2, Math.round(reloadInterval), 0);
-  return reloadInterval;
+  return Math.round(reloadInterval);
 }

--- a/src/controller/level-helper.js
+++ b/src/controller/level-helper.js
@@ -210,3 +210,20 @@ export function adjustSliding (oldPlaylist, newPlaylist) {
     newFragments[i].start += oldFragments[delta].start;
   }
 }
+
+export function computeReloadInterval (currentPlaylist, newPlaylist, lastRequestTime) {
+  let reloadInterval = 1000 * (newPlaylist.averagetargetduration ? newPlaylist.averagetargetduration : newPlaylist.targetduration);
+  if (currentPlaylist && newPlaylist.endSN === currentPlaylist.endSN) {
+    // follow HLS Spec, If the client reloads a Playlist file and finds that it has not
+    // changed then it MUST wait for a period of one-half the target
+    // duration before retrying.
+    reloadInterval /= 2;
+  }
+  // decrement reloadInterval with level loading delay
+  if (lastRequestTime) {
+    reloadInterval -= window.performance.now() - lastRequestTime;
+  }
+  // in any case, don't reload more than half of target duration
+  reloadInterval = Math.max(reloadInterval / 2, Math.round(reloadInterval));
+  return reloadInterval;
+}

--- a/src/controller/level-helper.js
+++ b/src/controller/level-helper.js
@@ -110,45 +110,38 @@ export function updateFragPTSDTS (details, frag, startPTS, endPTS, startDTS, end
 }
 
 export function mergeDetails (oldDetails, newDetails) {
-  let start = Math.max(oldDetails.startSN, newDetails.startSN) - newDetails.startSN,
-    end = Math.min(oldDetails.endSN, newDetails.endSN) - newDetails.startSN,
-    delta = newDetails.startSN - oldDetails.startSN,
-    oldfragments = oldDetails.fragments,
-    newfragments = newDetails.fragments,
-    ccOffset = 0,
-    PTSFrag;
-
   // potentially retrieve cached initsegment
   if (newDetails.initSegment && oldDetails.initSegment) {
     newDetails.initSegment = oldDetails.initSegment;
   }
 
   // check if old/new playlists have fragments in common
-  if (end < start) {
-    newDetails.PTSKnown = false;
-    return;
-  }
   // loop through overlapping SN and update startPTS , cc, and duration if any found
-  for (var i = start; i <= end; i++) {
-    let oldFrag = oldfragments[delta + i],
-      newFrag = newfragments[i];
-    if (newFrag && oldFrag) {
-      ccOffset = oldFrag.cc - newFrag.cc;
-      if (Number.isFinite(oldFrag.startPTS)) {
-        newFrag.start = newFrag.startPTS = oldFrag.startPTS;
-        newFrag.endPTS = oldFrag.endPTS;
-        newFrag.duration = oldFrag.duration;
-        newFrag.backtracked = oldFrag.backtracked;
-        newFrag.dropped = oldFrag.dropped;
-        PTSFrag = newFrag;
-      }
+  let ccOffset = 0;
+  let PTSFrag;
+  mapFragmentIntersection(oldDetails, newDetails, (oldFrag, newFrag) => {
+    ccOffset = oldFrag.cc - newFrag.cc;
+    if (Number.isFinite(oldFrag.startPTS)) {
+      newFrag.start = newFrag.startPTS = oldFrag.startPTS;
+      newFrag.endPTS = oldFrag.endPTS;
+      newFrag.duration = oldFrag.duration;
+      newFrag.backtracked = oldFrag.backtracked;
+      newFrag.dropped = oldFrag.dropped;
+      PTSFrag = newFrag;
     }
+    // PTS is known when there are overlapping segments
+    newDetails.PTSKnown = true;
+  });
+
+  if (!newDetails.PTSKnown) {
+    return;
   }
 
   if (ccOffset) {
     logger.log('discontinuity sliding from playlist, take drift into account');
-    for (i = 0; i < newfragments.length; i++) {
-      newfragments[i].cc += ccOffset;
+    const newFragments = newDetails.fragments;
+    for (let i = 0; i < newFragments.length; i++) {
+      newFragments[i].cc += ccOffset;
     }
   }
 
@@ -156,18 +149,59 @@ export function mergeDetails (oldDetails, newDetails) {
   if (PTSFrag) {
     updateFragPTSDTS(newDetails, PTSFrag, PTSFrag.startPTS, PTSFrag.endPTS, PTSFrag.startDTS, PTSFrag.endDTS);
   } else {
-    // ensure that delta is within oldfragments range
+    // ensure that delta is within oldFragments range
     // also adjust sliding in case delta is 0 (we could have old=[50-60] and new=old=[50-61])
     // in that case we also need to adjust start offset of all fragments
-    if (delta >= 0 && delta < oldfragments.length) {
-      // adjust start by sliding offset
-      let sliding = oldfragments[delta].start;
-      for (i = 0; i < newfragments.length; i++) {
-        newfragments[i].start += sliding;
-      }
-    }
+    adjustSliding(oldDetails, newDetails);
   }
   // if we are here, it means we have fragments overlapping between
   // old and new level. reliable PTS info is thus relying on old level
   newDetails.PTSKnown = oldDetails.PTSKnown;
+}
+
+export function mergeSubtitlePlaylists (oldPlaylist, newPlaylist) {
+  let lastIndex = -1;
+  mapFragmentIntersection(oldPlaylist, newPlaylist, (oldFrag, newFrag, index) => {
+    newFrag.start = oldFrag.start;
+    lastIndex = index;
+  });
+  if (lastIndex < 0) {
+    return;
+  }
+  const frags = newPlaylist.fragments;
+  for (let i = lastIndex + 1; i < frags.length; i++) {
+    frags[i].start = (frags[i - 1].start + frags[i - 1].duration);
+  }
+}
+
+export function mapFragmentIntersection (oldPlaylist, newPlaylist, intersectionFn) {
+  if (!oldPlaylist || !newPlaylist) {
+    return;
+  }
+
+  const start = Math.max(oldPlaylist.startSN, newPlaylist.startSN) - newPlaylist.startSN;
+  const end = Math.min(oldPlaylist.endSN, newPlaylist.endSN) - newPlaylist.startSN;
+  const delta = newPlaylist.startSN - oldPlaylist.startSN;
+
+  for (let i = start; i <= end; i++) {
+    const oldFrag = oldPlaylist.fragments[delta + i];
+    const newFrag = newPlaylist.fragments[i];
+    if (!oldFrag || !newFrag) {
+      break;
+    }
+    intersectionFn(oldFrag, newFrag, i);
+  }
+}
+
+export function adjustSliding (oldPlaylist, newPlaylist) {
+  const delta = newPlaylist.startSN - oldPlaylist.startSN;
+  const oldFragments = oldPlaylist.fragments;
+  const newFragments = newPlaylist.fragments;
+
+  if (delta < 0 || delta > oldFragments.length) {
+    return;
+  }
+  for (let i = 0; i < newFragments.length; i++) {
+    newFragments[i].start += oldFragments[delta].start;
+  }
 }

--- a/src/controller/level-helper.js
+++ b/src/controller/level-helper.js
@@ -159,16 +159,20 @@ export function mergeDetails (oldDetails, newDetails) {
   newDetails.PTSKnown = oldDetails.PTSKnown;
 }
 
-export function mergeSubtitlePlaylists (oldPlaylist, newPlaylist) {
+export function mergeSubtitlePlaylists (oldPlaylist, newPlaylist, referenceStart = 0) {
   let lastIndex = -1;
   mapFragmentIntersection(oldPlaylist, newPlaylist, (oldFrag, newFrag, index) => {
     newFrag.start = oldFrag.start;
     lastIndex = index;
   });
+
+  const frags = newPlaylist.fragments;
   if (lastIndex < 0) {
+    frags.forEach(frag => {
+      frag.start += referenceStart;
+    });
     return;
   }
-  const frags = newPlaylist.fragments;
   for (let i = lastIndex + 1; i < frags.length; i++) {
     frags[i].start = (frags[i - 1].start + frags[i - 1].duration);
   }

--- a/src/controller/level-helper.js
+++ b/src/controller/level-helper.js
@@ -224,6 +224,6 @@ export function computeReloadInterval (currentPlaylist, newPlaylist, lastRequest
     reloadInterval -= (window.performance.now() - lastRequestTime);
   }
   // in any case, don't reload more than half of target duration
-  reloadInterval = Math.max(reloadInterval / 2, Math.round(reloadInterval));
+  reloadInterval = Math.max(reloadInterval / 2, Math.round(reloadInterval), 0);
   return reloadInterval;
 }

--- a/src/controller/level-helper.js
+++ b/src/controller/level-helper.js
@@ -221,7 +221,7 @@ export function computeReloadInterval (currentPlaylist, newPlaylist, lastRequest
   }
   // decrement reloadInterval with level loading delay
   if (lastRequestTime) {
-    reloadInterval -= window.performance.now() - lastRequestTime;
+    reloadInterval -= (window.performance.now() - lastRequestTime);
   }
   // in any case, don't reload more than half of target duration
   reloadInterval = Math.max(reloadInterval / 2, Math.round(reloadInterval));

--- a/src/controller/level-helper.js
+++ b/src/controller/level-helper.js
@@ -173,6 +173,7 @@ export function mergeSubtitlePlaylists (oldPlaylist, newPlaylist, referenceStart
     });
     return;
   }
+
   for (let i = lastIndex + 1; i < frags.length; i++) {
     frags[i].start = (frags[i - 1].start + frags[i - 1].duration);
   }

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -52,17 +52,6 @@ class StreamController extends BaseStreamController {
     this._state = State.STOPPED;
   }
 
-  onHandlerDestroying () {
-    this.stopLoad();
-    super.onHandlerDestroying();
-  }
-
-  onHandlerDestroyed () {
-    this.state = State.STOPPED;
-    this.fragmentTracker = null;
-    super.onHandlerDestroyed();
-  }
-
   startLoad (startPosition) {
     if (this.levels) {
       const { lastCurrentTime, hls } = this;
@@ -102,23 +91,8 @@ class StreamController extends BaseStreamController {
   }
 
   stopLoad () {
-    let frag = this.fragCurrent;
-    if (frag) {
-      if (frag.loader) {
-        frag.loader.abort();
-      }
-
-      this.fragmentTracker.removeFragment(frag);
-      this.fragCurrent = null;
-    }
-    this.fragPrevious = null;
-    if (this.demuxer) {
-      this.demuxer.destroy();
-      this.demuxer = null;
-    }
-    this.clearInterval();
-    this.state = State.STOPPED;
     this.forceStartLoad = false;
+    super.stopLoad();
   }
 
   doTick () {

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -6,7 +6,7 @@ import Event from '../events';
 import { logger } from '../utils/logger';
 import Decrypter from '../crypt/decrypter';
 import { BufferHelper } from '../utils/buffer-helper';
-import { findFragmentByPTS } from './fragment-finders';
+import { findFragmentByPDT, findFragmentByPTS } from './fragment-finders';
 import { FragmentState } from './fragment-tracker';
 import BaseStreamController, { State } from './base-stream-controller';
 import { mergeSubtitlePlaylists } from './level-helper';
@@ -195,8 +195,14 @@ export class SubtitleStreamController extends BaseStreamController {
       }
 
       let foundFrag;
+      const fragPrevious = this.fragPrevious;
       if (bufferEnd < end) {
-        foundFrag = findFragmentByPTS(this.fragPrevious, fragments, bufferEnd, maxFragLookUpTolerance);
+        if (fragPrevious && trackDetails.hasProgramDateTime) {
+          foundFrag = findFragmentByPDT(fragments, fragPrevious.endProgramDateTime, maxFragLookUpTolerance);
+        }
+        if (!foundFrag) {
+          foundFrag = findFragmentByPTS(fragPrevious, fragments, bufferEnd, maxFragLookUpTolerance);
+        }
       } else {
         foundFrag = fragments[fragLen - 1];
       }

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -35,12 +35,6 @@ export class SubtitleStreamController extends BaseStreamController {
     this.decrypter = new Decrypter(hls, hls.config);
   }
 
-  onHandlerDestroyed () {
-    this.fragmentTracker = null;
-    this.state = State.STOPPED;
-    super.onHandlerDestroyed();
-  }
-
   onSubtitleFragProcessed (data) {
     const { frag, success } = data;
     this.fragPrevious = frag;

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -133,17 +133,10 @@ export class SubtitleStreamController extends TaskLoop {
   }
 
   // Got a new set of subtitle fragments.
-  onSubtitleTrackLoaded (data) {
-    const { id, details } = data;
-
+  onSubtitleTrackLoaded () {
     if (!this.tracks) {
       logger.warn('Can not update subtitle details, no tracks found');
       return;
-    }
-
-    if (this.tracks[id]) {
-      logger.log('Updating subtitle track details');
-      this.tracks[id].details = details;
     }
 
     this.setInterval(TICK_INTERVAL);

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -5,25 +5,15 @@
 import Event from '../events';
 import { logger } from '../utils/logger';
 import Decrypter from '../crypt/decrypter';
-import TaskLoop from '../task-loop';
 import { BufferHelper } from '../utils/buffer-helper';
-import { findFragmentByPTS, findFragmentByPDT } from './fragment-finders';
+import { findFragmentByPTS } from './fragment-finders';
 import { FragmentState } from './fragment-tracker';
+import BaseStreamController, { State } from './base-stream-controller';
 
 const { performance } = window;
-
-export const SubtitleStreamControllerState = {
-  STOPPED: 'STOPPED',
-  IDLE: 'IDLE',
-  KEY_LOADING: 'KEY_LOADING',
-  FRAG_LOADING: 'FRAG_LOADING'
-};
-
-const State = SubtitleStreamControllerState;
-
 const TICK_INTERVAL = 500; // how often to tick in ms
 
-export class SubtitleStreamController extends TaskLoop {
+export class SubtitleStreamController extends BaseStreamController {
   constructor (hls, fragmentTracker) {
     super(hls,
       Event.MEDIA_ATTACHED,
@@ -52,24 +42,20 @@ export class SubtitleStreamController extends TaskLoop {
   }
 
   onSubtitleFragProcessed (data) {
+    const { frag, success } = data;
+    this.fragPrevious = frag;
     this.state = State.IDLE;
-
-    if (!data.success) {
+    if (!success) {
       return;
     }
 
     const buffered = this.tracksBuffered[this.currentTrackId];
-    const frag = data.frag;
-
-    this.fragPrevious = frag;
-
     if (!buffered) {
       return;
     }
 
     // Create/update a buffered array matching the interface used by BufferHelper.bufferedInfo
     // so we can re-use the logic used to detect how much have been buffered
-    // FIXME: put this in a utility function or proper object for time-ranges manipulation?
     let timeRange;
     for (let i = 0; i < buffered.length; i++) {
       if (frag.start >= buffered[i].start && frag.start <= buffered[i].end) {
@@ -81,10 +67,11 @@ export class SubtitleStreamController extends TaskLoop {
     if (timeRange) {
       timeRange.end = frag.start + frag.duration;
     } else {
-      buffered.push({
+      timeRange = {
         start: frag.start,
         end: frag.start + frag.duration
-      });
+      };
+      buffered.push(timeRange);
     }
   }
 
@@ -98,7 +85,7 @@ export class SubtitleStreamController extends TaskLoop {
     this.state = State.STOPPED;
   }
 
-  // If something goes wrong, procede to next frag, if we were processing one.
+  // If something goes wrong, proceed to next frag, if we were processing one.
   onError (data) {
     let frag = data.frag;
     // don't handle error not related to subtitle fragment
@@ -120,7 +107,7 @@ export class SubtitleStreamController extends TaskLoop {
 
   onSubtitleTrackSwitch (data) {
     this.currentTrackId = data.id;
-    this.fragPrevious = null;
+
     if (!this.tracks || this.currentTrackId === -1) {
       this.clearInterval();
       return;
@@ -166,7 +153,6 @@ export class SubtitleStreamController extends TaskLoop {
         // decrypt the subtitles
         this.decrypter.decrypt(data.payload, decryptData.key.buffer, decryptData.iv.buffer, function (decryptedData) {
           let endTime = performance.now();
-
           hls.trigger(Event.FRAG_DECRYPTED, { frag: fragLoaded, payload: decryptedData, stats: { tstart: startTime, tdecrypt: endTime } });
         });
       }
@@ -181,22 +167,20 @@ export class SubtitleStreamController extends TaskLoop {
 
     switch (this.state) {
     case State.IDLE: {
-      const { config, currentTrackId: trackId, tracks } = this;
+      const { config, currentTrackId: trackId, fragmentTracker, media, tracks } = this;
       if (!tracks || !tracks[trackId] || !tracks[trackId].details) {
         break;
       }
 
       const { maxBufferHole, maxFragLookUpTolerance } = config;
       const maxConfigBuffer = Math.min(config.maxBufferLength, config.maxMaxBufferLength);
-
-      const bufferedInfo = BufferHelper.bufferedInfo(this._getBuffered(), this.media.currentTime, maxBufferHole);
+      const bufferedInfo = BufferHelper.bufferedInfo(this._getBuffered(), media.currentTime, maxBufferHole);
       const { end: bufferEnd, len: bufferLen } = bufferedInfo;
 
       const trackDetails = tracks[trackId].details;
       const fragments = trackDetails.fragments;
       const fragLen = fragments.length;
       const end = fragments[fragLen - 1].start + fragments[fragLen - 1].duration;
-      const fragPrevious = this.fragPrevious;
 
       if (bufferLen > maxConfigBuffer) {
         return;
@@ -204,11 +188,7 @@ export class SubtitleStreamController extends TaskLoop {
 
       let foundFrag;
       if (bufferEnd < end) {
-        if (fragPrevious) {
-          foundFrag = fragments[fragPrevious.sn - fragments[0].sn + 1];
-        } else {
-          foundFrag = findFragmentByPTS(null, fragments, bufferEnd, maxFragLookUpTolerance);
-        }
+        foundFrag = findFragmentByPTS(this.fragPrevious, fragments, bufferEnd, maxFragLookUpTolerance);
       } else {
         foundFrag = fragments[fragLen - 1];
       }
@@ -217,9 +197,8 @@ export class SubtitleStreamController extends TaskLoop {
         logger.log(`Loading key for ${foundFrag.sn}`);
         this.state = State.KEY_LOADING;
         this.hls.trigger(Event.KEY_LOADING, { frag: foundFrag });
-      } else if (foundFrag && this.fragmentTracker.getState(foundFrag) === FragmentState.NOT_LOADED) {
+      } else if (foundFrag && fragmentTracker.getState(foundFrag) === FragmentState.NOT_LOADED) {
         // only load if fragment is not loaded
-        foundFrag.trackId = trackId; // Frags don't know their subtitle track ID, so let's just add that...
         this.fragCurrent = foundFrag;
         this.state = State.FRAG_LOADING;
         this.hls.trigger(Event.FRAG_LOADING, { frag: foundFrag });

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -54,19 +54,21 @@ export class SubtitleStreamController extends BaseStreamController {
     // Create/update a buffered array matching the interface used by BufferHelper.bufferedInfo
     // so we can re-use the logic used to detect how much have been buffered
     let timeRange;
+    const fragStart = frag.start;
     for (let i = 0; i < buffered.length; i++) {
-      if (frag.start >= buffered[i].start && frag.start <= buffered[i].end) {
+      if (fragStart >= buffered[i].start && fragStart <= buffered[i].end) {
         timeRange = buffered[i];
         break;
       }
     }
 
+    const fragEnd = frag.start + frag.duration;
     if (timeRange) {
-      timeRange.end = frag.start + frag.duration;
+      timeRange.end = fragEnd;
     } else {
       timeRange = {
-        start: frag.start,
-        end: frag.start + frag.duration
+        start: fragStart,
+        end: fragEnd
       };
       buffered.push(timeRange);
     }

--- a/src/controller/subtitle-track-controller.js
+++ b/src/controller/subtitle-track-controller.js
@@ -66,7 +66,6 @@ class SubtitleTrackController extends EventHandler {
   onManifestLoaded (data) {
     let tracks = data.subtitles || [];
     this.tracks = tracks;
-    // this.trackId = -1;
     this.hls.trigger(Event.SUBTITLE_TRACKS_UPDATED, { subtitleTracks: tracks });
 
     // loop through available subtitle tracks and autoselect default if needed

--- a/src/controller/subtitle-track-controller.js
+++ b/src/controller/subtitle-track-controller.js
@@ -10,7 +10,8 @@ class SubtitleTrackController extends EventHandler {
       Event.MEDIA_DETACHING,
       Event.MANIFEST_LOADING,
       Event.MANIFEST_LOADED,
-      Event.SUBTITLE_TRACK_LOADED);
+      Event.SUBTITLE_TRACK_LOADED,
+      Event.LEVEL_UPDATED);
     this.tracks = [];
     this.trackId = -1;
     this.media = null;
@@ -125,13 +126,18 @@ class SubtitleTrackController extends EventHandler {
     logger.log(`subtitle track ${id} loaded`);
     const { live, url, targetduration } = details;
     if (live) {
-      mergeSubtitlePlaylists(currentTrack.details, details);
+      mergeSubtitlePlaylists(currentTrack, details, this.lastAVStart);
       currentTrack.details = details;
       this._setReloadTimer(id, url, targetduration);
     } else {
       currentTrack.details = details;
       this._stopTimer();
     }
+  }
+
+  onLevelUpdated ({ details }) {
+    const frags = details.fragments;
+    this.lastAVStart = frags.length ? frags[0].start : 0;
   }
 
   /** get alternate subtitle tracks list from playlist **/

--- a/src/controller/subtitle-track-controller.js
+++ b/src/controller/subtitle-track-controller.js
@@ -126,7 +126,7 @@ class SubtitleTrackController extends EventHandler {
     logger.log(`subtitle track ${id} loaded`);
     const { live, url, targetduration } = details;
     if (live) {
-      mergeSubtitlePlaylists(currentTrack, details, this.lastAVStart);
+      mergeSubtitlePlaylists(currentTrack.details, details, this.lastAVStart);
       currentTrack.details = details;
       this._setReloadTimer(id, url, targetduration);
     } else {

--- a/src/controller/subtitle-track-controller.js
+++ b/src/controller/subtitle-track-controller.js
@@ -13,6 +13,7 @@ class SubtitleTrackController extends EventHandler {
     this.tracks = [];
     this.trackId = -1;
     this.media = null;
+    this.stopped = true;
 
     /**
      * @member {boolean} subtitleDisplay Enable/disable subtitle display rendering
@@ -89,8 +90,8 @@ class SubtitleTrackController extends EventHandler {
     const { id, details } = data;
     const { trackId, tracks } = this;
     const currentTrack = tracks[trackId];
-    if (id >= tracks.length || id !== trackId || !currentTrack) {
-      this.stopLoad();
+    if (id >= tracks.length || id !== trackId || !currentTrack || this.stopped) {
+      this._clearReloadTimer();
       return;
     }
 
@@ -102,19 +103,18 @@ class SubtitleTrackController extends EventHandler {
         this._loadCurrentTrack();
       }, reloadInterval);
     } else {
-      this.stopLoad();
+      this._clearReloadTimer();
     }
   }
 
   startLoad () {
+    this.stopped = false;
     this._loadCurrentTrack();
   }
 
   stopLoad () {
-    if (this.timer) {
-      clearTimeout(this.timer);
-      this.timer = null;
-    }
+    this.stopped = true;
+    this._clearReloadTimer();
   }
 
   /** get alternate subtitle tracks list from playlist **/
@@ -132,6 +132,13 @@ class SubtitleTrackController extends EventHandler {
     if (this.trackId !== subtitleTrackId) {
       this._toggleTrackModes(subtitleTrackId);
       this._setSubtitleTrackInternal(subtitleTrackId);
+    }
+  }
+
+  _clearReloadTimer () {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
     }
   }
 

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -359,7 +359,7 @@ class TimelineController extends EventHandler {
 
     // Parse the WebVTT file contents.
     WebVTTParser.parse(payload, this.initPTS[frag.cc], vttCCs, frag.cc, (cues) => {
-      const currentTrack = tracks[frag.trackId];
+      const currentTrack = tracks[frag.level];
 
       if (this.config.renderNatively) {
         cues.filter(cue => !currentTrack.cues.getCueById(cue.id))
@@ -367,7 +367,7 @@ class TimelineController extends EventHandler {
             currentTrack.addCue(cue);
           });
       } else {
-        let trackId = currentTrack.default ? 'default' : 'subtitles' + frag.trackId;
+        let trackId = currentTrack.default ? 'default' : 'subtitles' + frag.level;
         hls.trigger(Event.CUES_PARSED, { type: 'subtitles', cues: cues, track: trackId });
       }
       hls.trigger(Event.SUBTITLE_FRAG_PROCESSED, { success: true, frag: frag });

--- a/src/hls.js
+++ b/src/hls.js
@@ -208,7 +208,7 @@ export default class Hls extends Observer {
     // optional subtitle controllers
     Controller = config.subtitleStreamController;
     if (Controller) {
-      coreComponents.push(new Controller(this, fragmentTracker));
+      networkControllers.push(new Controller(this, fragmentTracker));
     }
     Controller = config.timelineController;
     if (Controller) {

--- a/src/hls.js
+++ b/src/hls.js
@@ -191,7 +191,7 @@ export default class Hls extends Observer {
        * @member {SubtitleTrackController} subtitleTrackController
        */
       this.subtitleTrackController = subtitleTrackController;
-      coreComponents.push(subtitleTrackController);
+      networkControllers.push(subtitleTrackController);
     }
 
     Controller = config.emeController;

--- a/tests/unit/controller/level-helper.js
+++ b/tests/unit/controller/level-helper.js
@@ -44,6 +44,13 @@ describe('Level-Helper Tests', function () {
       expect(actual).to.deep.equal([5]);
     });
 
+    it('can iterate over the entire segment array', function () {
+      const oldPlaylist = generatePlaylist([1, 2, 3]);
+      const newPlaylist = generatePlaylist([1, 2, 3]);
+      const actual = getIteratedSequence(oldPlaylist, newPlaylist);
+      expect(actual).to.deep.equal([1, 2, 3]);
+    });
+
     it('can iterate when overlapping happens at the start of the old playlist', function () {
       const oldPlaylist = generatePlaylist([5, 6, 7, 8]);
       const newPlaylist = generatePlaylist([3, 4, 5, 6]);
@@ -102,6 +109,14 @@ describe('Level-Helper Tests', function () {
       LevelHelper.mergeSubtitlePlaylists(oldPlaylist, newPlaylist);
       const actual = newPlaylist.fragments.map(f => f.start);
       expect(actual).to.deep.equal([0, 5, 10]);
+    });
+
+    it('adjusts sliding using the reference start if there is no segment overlap', function () {
+      const oldPlaylist = generatePlaylist([1, 2, 3]);
+      const newPlaylist = generatePlaylist([5, 6, 7]);
+      LevelHelper.mergeSubtitlePlaylists(oldPlaylist, newPlaylist, 30);
+      const actual = newPlaylist.fragments.map(f => f.start);
+      expect(actual).to.deep.equal([30, 35, 40]);
     });
 
     it('does not extrapolate if the new playlist starts before the old', function () {

--- a/tests/unit/controller/level-helper.js
+++ b/tests/unit/controller/level-helper.js
@@ -189,7 +189,7 @@ describe('LevelHelper Tests', function () {
       expect(actual).to.equal(4000);
     });
 
-    it('returns 0 if request time causes the interval to be negative', function () {
+    it('returns a minimum of half the target duration', function () {
       const oldPlaylist = generatePlaylist([1, 2]);
       const newPlaylist = generatePlaylist([3, 4]);
       newPlaylist.averagetargetduration = 5;
@@ -197,7 +197,7 @@ describe('LevelHelper Tests', function () {
       const clock = sandbox.useFakeTimers();
       clock.tick(9000);
       const actual = LevelHelper.computeReloadInterval(oldPlaylist, newPlaylist, 1000);
-      expect(actual).to.equal(0);
+      expect(actual).to.equal(2500);
     });
   });
 });

--- a/tests/unit/controller/level-helper.js
+++ b/tests/unit/controller/level-helper.js
@@ -188,5 +188,16 @@ describe('LevelHelper Tests', function () {
       const actual = LevelHelper.computeReloadInterval(oldPlaylist, newPlaylist, 1000);
       expect(actual).to.equal(4000);
     });
+
+    it('returns 0 if request time causes the interval to be negative', function () {
+      const oldPlaylist = generatePlaylist([1, 2]);
+      const newPlaylist = generatePlaylist([3, 4]);
+      newPlaylist.averagetargetduration = 5;
+
+      const clock = sandbox.useFakeTimers();
+      clock.tick(9000);
+      const actual = LevelHelper.computeReloadInterval(oldPlaylist, newPlaylist, 1000);
+      expect(actual).to.equal(0);
+    });
   });
 });

--- a/tests/unit/controller/level-helper.js
+++ b/tests/unit/controller/level-helper.js
@@ -1,0 +1,118 @@
+import * as LevelHelper from '../../../src/controller/level-helper';
+import Level from '../../../src/loader/level';
+import Fragment from '../../../src/loader/fragment';
+import sinon from 'sinon';
+
+const generatePlaylist = (sequenceNumbers) => {
+  const playlist = new Level('');
+  playlist.startSN = sequenceNumbers[0];
+  playlist.endSN = sequenceNumbers[sequenceNumbers.length - 1];
+  playlist.fragments = sequenceNumbers.map((n, i) => {
+    const frag = new Fragment();
+    frag.sn = n;
+    frag.start = i * 5;
+    frag.duration = 5;
+    return frag;
+  });
+  return playlist;
+};
+
+const getIteratedSequence = (oldPlaylist, newPlaylist) => {
+  const actual = [];
+  LevelHelper.mapFragmentIntersection(oldPlaylist, newPlaylist, (oldFrag, newFrag) => {
+    if (oldFrag.sn !== newFrag.sn) {
+      throw new Error('Expected old frag and new frag to have the same SN');
+    }
+    actual.push(newFrag.sn);
+  });
+  return actual;
+};
+
+describe('Level-Helper Tests', function () {
+  describe('mapSegmentIntersection', function () {
+    it('iterates over the intersection of the fragment arrays', function () {
+      const oldPlaylist = generatePlaylist([1, 2, 3, 4, 5]);
+      const newPlaylist = generatePlaylist([3, 4, 5, 6, 7]);
+      const actual = getIteratedSequence(oldPlaylist, newPlaylist);
+      expect(actual).to.deep.equal([3, 4, 5]);
+    });
+
+    it('can iterate with one overlapping fragment', function () {
+      const oldPlaylist = generatePlaylist([1, 2, 3, 4, 5]);
+      const newPlaylist = generatePlaylist([5, 6, 7, 8, 9]);
+      const actual = getIteratedSequence(oldPlaylist, newPlaylist);
+      expect(actual).to.deep.equal([5]);
+    });
+
+    it('can iterate when overlapping happens at the start of the old playlist', function () {
+      const oldPlaylist = generatePlaylist([5, 6, 7, 8]);
+      const newPlaylist = generatePlaylist([3, 4, 5, 6]);
+      const actual = getIteratedSequence(oldPlaylist, newPlaylist);
+      expect(actual).to.deep.equal([5, 6]);
+    });
+
+    it('never executes the callback if no intersection exists', function () {
+      const oldPlaylist = generatePlaylist([1, 2, 3, 4, 5]);
+      const newPlaylist = generatePlaylist([10, 11, 12]);
+      const actual = getIteratedSequence(oldPlaylist, newPlaylist);
+      expect(actual).to.deep.equal([]);
+    });
+
+    it('exits early if either playlist does not exist', function () {
+      let oldPlaylist = null;
+      let newPlaylist = generatePlaylist([10, 11, 12]);
+      expect(getIteratedSequence(oldPlaylist, newPlaylist)).to.deep.equal([]);
+      oldPlaylist = newPlaylist;
+      newPlaylist = null;
+      expect(getIteratedSequence(oldPlaylist, newPlaylist)).to.deep.equal([]);
+    });
+  });
+
+  describe('adjustSliding', function () {
+    // generatePlaylist creates fragments with a duration of 5 seconds
+    it('adds the start time of the first comment segment to all other segment', function () {
+      const oldPlaylist = generatePlaylist([1, 2, 3]); // start times: 0, 5, 10
+      const newPlaylist = generatePlaylist([3, 4, 5]);
+      LevelHelper.adjustSliding(oldPlaylist, newPlaylist);
+      const actual = newPlaylist.fragments.map(f => f.start);
+      expect(actual).to.deep.equal([10, 15, 20]);
+    });
+
+    it('does not apply sliding if no common segments exist', function () {
+      const oldPlaylist = generatePlaylist([1, 2, 3]);
+      const newPlaylist = generatePlaylist([5, 6, 7]);
+      LevelHelper.adjustSliding(oldPlaylist, newPlaylist);
+      const actual = newPlaylist.fragments.map(f => f.start);
+      expect(actual).to.deep.equal([0, 5, 10]);
+    });
+  });
+
+  describe('mergeSubtitlePlaylists', function () {
+    it('transfers start times where segments overlap, and extrapolates the start of any new segment', function () {
+      const oldPlaylist = generatePlaylist([1, 2, 3, 4]); // start times: 0, 5, 10, 15
+      const newPlaylist = generatePlaylist([2, 3, 4, 5]);
+      LevelHelper.mergeSubtitlePlaylists(oldPlaylist, newPlaylist);
+      const actual = newPlaylist.fragments.map(f => f.start);
+      expect(actual).to.deep.equal([5, 10, 15, 20]);
+    });
+
+    it('does not change start times when there is no segment overlap', function () {
+      const oldPlaylist = generatePlaylist([1, 2, 3]);
+      const newPlaylist = generatePlaylist([5, 6, 7]);
+      LevelHelper.mergeSubtitlePlaylists(oldPlaylist, newPlaylist);
+      const actual = newPlaylist.fragments.map(f => f.start);
+      expect(actual).to.deep.equal([0, 5, 10]);
+    });
+
+    it('does not extrapolate if the new playlist starts before the old', function () {
+      const oldPlaylist = generatePlaylist([3, 4, 5]);
+      oldPlaylist.fragments.forEach(f => {
+        f.start += 10;
+      });
+      const newPlaylist = generatePlaylist([1, 2, 3]);
+      LevelHelper.mergeSubtitlePlaylists(oldPlaylist, newPlaylist);
+      const actual = newPlaylist.fragments.map(f => f.start);
+      expect(actual).to.deep.equal([0, 5, 10]);
+    });
+  });
+});

--- a/tests/unit/controller/subtitle-stream-controller.js
+++ b/tests/unit/controller/subtitle-stream-controller.js
@@ -85,8 +85,9 @@ describe('SubtitleStreamController', function () {
       });
     });
 
-    it('should add details to track object in list', function () {
-      expect(streamController.tracks[1].details).to.equal(detailsMock);
+    // Details are in subtitle-track-controller.js' onSubtitleTrackLoaded handler
+    it('should not add details to track object in list', function () {
+      expect(streamController.tracks[1].details).to.not.exist;
     });
 
     it('should call setInterval', function () {

--- a/tests/unit/controller/subtitle-stream-controller.js
+++ b/tests/unit/controller/subtitle-stream-controller.js
@@ -17,18 +17,18 @@ const tracksMock = [
 describe('SubtitleStreamController', function () {
   let hls;
   let fragmentTracker;
-  let streamController;
+  let subtitleStreamController;
 
   beforeEach(function () {
     hls = new Hls({});
     fragmentTracker = new FragmentTracker(hls);
-    streamController = new SubtitleStreamController(hls, fragmentTracker);
+    subtitleStreamController = new SubtitleStreamController(hls, fragmentTracker);
 
-    streamController.onMediaAttached(mediaMock);
+    subtitleStreamController.onMediaAttached(mediaMock);
   });
 
   afterEach(function () {
-    streamController.onMediaDetaching(mediaMock);
+    subtitleStreamController.onMediaDetaching(mediaMock);
   });
 
   describe('onSubtitleTracksUpdate', function () {
@@ -39,15 +39,15 @@ describe('SubtitleStreamController', function () {
     });
 
     it('should update tracks list', function () {
-      expect(streamController.tracks).to.equal(tracksMock);
+      expect(subtitleStreamController.tracks).to.equal(tracksMock);
     });
   });
 
   describe('onSubtitleTrackSwitch', function () {
     beforeEach(function () {
-      streamController.tracks = tracksMock;
-      streamController.clearInterval = sinon.spy();
-      streamController.setInterval = sinon.spy();
+      subtitleStreamController.tracks = tracksMock;
+      subtitleStreamController.clearInterval = sinon.spy();
+      subtitleStreamController.setInterval = sinon.spy();
 
       hls.trigger(Event.SUBTITLE_TRACK_SWITCH, {
         id: 0
@@ -55,57 +55,75 @@ describe('SubtitleStreamController', function () {
     });
 
     it('should call setInterval if details available', function () {
-      expect(streamController.setInterval).to.have.been.calledOnce;
+      expect(subtitleStreamController.setInterval).to.have.been.calledOnce;
     });
 
     it('should call clearInterval if no tracks present', function () {
-      streamController.tracks = null;
+      subtitleStreamController.tracks = null;
       hls.trigger(Event.SUBTITLE_TRACK_SWITCH, {
         id: 0
       });
-      expect(streamController.clearInterval).to.have.been.calledOnce;
+      expect(subtitleStreamController.clearInterval).to.have.been.calledOnce;
     });
 
     it('should call clearInterval if new track id === -1', function () {
       hls.trigger(Event.SUBTITLE_TRACK_SWITCH, {
         id: -1
       });
-      expect(streamController.clearInterval).to.have.been.calledOnce;
+      expect(subtitleStreamController.clearInterval).to.have.been.calledOnce;
     });
   });
 
   describe('onSubtitleTrackLoaded', function () {
-    let detailsMock = {};
-
     beforeEach(function () {
-      streamController.setInterval = sinon.spy();
-      streamController.tracks = tracksMock;
-      hls.trigger(Event.SUBTITLE_TRACK_LOADED, {
-        id: 1, details: detailsMock
-      });
+      subtitleStreamController.setInterval = sinon.spy();
+      subtitleStreamController.tracks = tracksMock;
     });
 
     // Details are in subtitle-track-controller.js' onSubtitleTrackLoaded handler
-    it('should not add details to track object in list', function () {
-      expect(streamController.tracks[1].details).to.not.exist;
-    });
-
-    it('should call setInterval', function () {
-      expect(streamController.setInterval).to.have.been.calledOnce;
-    });
-
-    it('should not crash when no tracks present', function () {
-      streamController.tracks = null;
+    it('should handle the event if the data matches the current track', function () {
+      const details = { foo: 'bar' };
+      subtitleStreamController.currentTrackId = 1;
       hls.trigger(Event.SUBTITLE_TRACK_LOADED, {
-        id: 0, details: {}
+        id: 1, details
       });
+      expect(subtitleStreamController.tracks[1].details).to.equal(details);
+      expect(subtitleStreamController.setInterval).to.have.been.calledOnce;
     });
 
-    it('should not crash when no track id does not exist', function () {
-      streamController.tracks = null;
+    it('should ignore the event if the data does not match the current track', function () {
+      const details = { foo: 'bar' };
+      subtitleStreamController.currentTrackId = 0;
       hls.trigger(Event.SUBTITLE_TRACK_LOADED, {
-        id: 5, details: {}
+        id: 1, details
       });
+      expect(subtitleStreamController.tracks[0].details).to.not.equal(details);
+      expect(subtitleStreamController.setInterval).to.not.have.been.called;
+    });
+
+    it('should ignore the event if there are no tracks, or the id is not within the tracks array', function () {
+      subtitleStreamController.tracks = [];
+      subtitleStreamController.trackId = 0;
+      const details = { foo: 'bar' };
+      hls.trigger(Event.SUBTITLE_TRACK_LOADED, {
+        id: 0, details
+      });
+      expect(subtitleStreamController.tracks[0]).to.not.exist;
+      expect(subtitleStreamController.setInterval).to.not.have.been.called;
+    });
+  });
+
+  describe('onLevelLoaded', function () {
+    it('records the start time of the last known A/V track', function () {
+      hls.trigger(Event.LEVEL_UPDATED, {
+        details: { fragments: [{ start: 5 }] }
+      });
+      expect(subtitleStreamController.lastAVStart).to.equal(5);
+
+      hls.trigger(Event.LEVEL_UPDATED, {
+        details: { fragments: [] }
+      });
+      expect(subtitleStreamController.lastAVStart).to.equal(0);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2822,13 +2822,6 @@ esdoc-type-inference-plugin@^1.0.0:
   resolved "https://registry.yarnpkg.com/esdoc-type-inference-plugin/-/esdoc-type-inference-plugin-1.0.2.tgz#916e3f756de1d81d9c0dbe1c008e8dafd322cfaf"
   integrity sha512-tMIcEHNe1uhUGA7lT1UTWc9hs2dzthnTgmqXpmeUhurk7fL2tinvoH+IVvG/sLROzwOGZQS9zW/F9KWnpMzLIQ==
 
-esdoc-typescript-plugin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/esdoc-typescript-plugin/-/esdoc-typescript-plugin-1.0.1.tgz#d4b929677f2ee5587a86ec70e766537040b98662"
-  integrity sha512-QV9rdis5PkypVK1fh2wuESZPQZUVjTwt4hj97Pivb9M8wGPMOTxYu5ofkyGWm3xgNL+K0VxZY6TGEO07kfGAtg==
-  dependencies:
-    typescript "^2.8.3"
-
 esdoc-undocumented-identifier-plugin@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/esdoc-undocumented-identifier-plugin/-/esdoc-undocumented-identifier-plugin-1.0.0.tgz#82e05d371c32d12871140f1d5c81ec99fd9cc2c8"
@@ -2912,13 +2905,6 @@ eslint-plugin-standard@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-3.1.0.tgz#2a9e21259ba4c47c02d53b2d0c9135d4b1022d47"
   integrity sha512-fVcdyuKRr0EZ4fjWl3c+gp1BANFJD1+RaWa2UPYfMZ6jCtp5RG00kSaXnK/dE5sYzt4kaWJ9qdxqUfc0d9kX0w==
-
-eslint-plugin-typescript@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-typescript/-/eslint-plugin-typescript-0.12.0.tgz#e23d58cb27fe28e89fc641a1f20e8d862cb99aef"
-  integrity sha512-2+DNE8nTvdNkhem/FBJXLPSeMDOZL68vHHNfTbM+PBc5iAuwBe8xLSQubwKxABqSZDwUHg+mwGmv5c2NlImi0Q==
-  dependencies:
-    requireindex "~1.1.0"
 
 eslint-scope@^3.7.1:
   version "3.7.3"
@@ -5135,12 +5121,7 @@ lodash.toarray@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
   integrity sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
 
-lodash.unescape@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
-  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
-
-lodash@^4.0.0, lodash@^4.1.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0:
+lodash@^4.0.0, lodash@^4.1.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -6724,11 +6705,6 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
-requireindex@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
-  integrity sha1-5UBLgVV+91225JxacgBIk/4D4WI=
-
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -6899,11 +6875,6 @@ semver-diff@^2.0.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
-
-semver@5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
-  integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
 
 send@0.16.2:
   version "0.16.2"
@@ -7685,29 +7656,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-typescript-eslint-parser@^21.0.1:
-  version "21.0.1"
-  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-21.0.1.tgz#710ea628a72144e1ec3a1d6b9f5b2b0a5a520e04"
-  integrity sha512-rdtAzg0eTTv/+YRLBJZBAAuOHHyYiElE2HdkaOGf9kKGce811zP3JRPzDybCJQamdsxyEsMe6CyIk2JCEnw/4g==
-  dependencies:
-    eslint-scope "^4.0.0"
-    eslint-visitor-keys "^1.0.0"
-    lodash "^4.17.11"
-    typescript-estree "5.0.0"
-
-typescript-estree@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/typescript-estree/-/typescript-estree-5.0.0.tgz#6aaa33b96abf5edce165099630e2ccd997a95609"
-  integrity sha512-/FHoH7ECP+Y6CLS7MdRD0Hu7b3HgsD7k6ArNWgoXK3fW0eSZGj+t04Mf4aQ6EBj04WoHALkReYMfGbTzaDPKEg==
-  dependencies:
-    lodash.unescape "4.0.1"
-    semver "5.5.0"
-
-typescript@^2.8.3:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
-  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
 uglify-es@^3.3.4:
   version "3.3.9"


### PR DESCRIPTION
### This PR will...
- Start and stop subtitle loading in sync with `startLoad()/stopLoad()` API calls
- Compute sliding & merge subtitle playlists during live playback
- Fix shared references between `subtitle-track-controller` and `subtitle-stream-controller`
- Refactoring:
    - Extend `subtitle-stream-controller` from `base-stream-controller`
    - Move more shared logic into `base-stream-controller`
    - Move live reload interval calculation into a shared function & import into `subtitle-track-controller`
    - Remove the `trackId` from subtitle fragments, and refer to them by their `level` property
    - Several other minor refactorings (flipped conditionals, destructuring args, organizing functions)
- Add a bunch of unit tests

### Why is this Pull Request needed?

Live subtitle playback is not functioning correctly - on first glance, it appears that sliding isn't being calculated between live refreshes. This is true, but in the course of fixing it I noticed that the live VTT implementation was incomplete and had several unhandled edge cases.

### Are there any points in the code the reviewer needs to double check?
- Was there a good reason why `trackId` was assigned to fragments over using the `level` property?

### Resolves issues:
JW8-2659
