### PR TITLE
[JW8-2440] Implement LHLS prefetch manifest parsing

### DIFF
--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -1,5 +1,5 @@
-import PlaylistLoader from '../../../src/loader/playlist-loader';
 import M3U8Parser from '../../../src/loader/m3u8-parser';
+import { mergeDetails } from '../../../src/controller/level-helper';
 
 describe('PlaylistLoader', function () {
   it('parses empty manifest returns empty array', function () {
@@ -846,5 +846,133 @@ http://dummy.url.com/hls/live/segment/segment_022916_164500865_719928.ts
     expect(result.targetduration).to.equal(7);
     expect(result.fragments[0].url).to.equal('http://dummy.url.com/180724_Allison VLOG v3_00001.ts');
     expect(result.fragments[1].url).to.equal('http://dummy.url.com/180724_Allison VLOG v3_00002.ts');
+  });
+
+  describe('LHLS Parsing', function () {
+    const level = `#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:2
+#EXT-X-MEDIA-SEQUENCE: 0
+#EXT-X-DISCONTINUITY-SEQUENCE: 0
+#EXT-X-PROGRAM-DATE-TIME:2018-09-05T20:59:06.531Z
+#EXTINF:2.000
+https://foo.com/bar/0.ts
+#EXT-X-PROGRAM-DATE-TIME:2018-09-05T20:59:08.531Z
+#EXTINF:2.000
+https://foo.com/bar/1.ts
+
+#EXT-X-PREFETCH:https://foo.com/bar/2.ts
+    `;
+    const levelRefreshed = `#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:2
+#EXT-X-MEDIA-SEQUENCE: 1
+#EXT-X-DISCONTINUITY-SEQUENCE: 0
+#EXT-X-PROGRAM-DATE-TIME:2018-09-05T20:59:08.531Z
+#EXTINF:2.000
+https://foo.com/bar/1.ts
+#EXT-X-PROGRAM-DATE-TIME:2018-09-05T20:59:10.531Z
+#EXTINF:2.000
+https://foo.com/bar/2.ts
+
+#EXT-X-PREFETCH:https://foo.com/bar/3.ts
+    `;
+    const levelWithDiscontinuity = `#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:2
+#EXT-X-MEDIA-SEQUENCE: 100
+#EXT-X-DISCONTINUITY-SEQUENCE: 5
+#EXT-X-PROGRAM-DATE-TIME:2018-09-05T20:59:06.531Z
+#EXTINF:2.000
+https://foo.com/bar/0.ts
+#EXT-X-PROGRAM-DATE-TIME:2018-09-05T20:59:08.531Z
+#EXTINF:2.000
+https://foo.com/bar/1.ts
+
+#EXT-X-PREFETCH-DISCONTINUITY
+#EXT-X-PREFETCH:https://foo.com/bar/5.ts
+    `;
+
+    it('Adds prefetch segments to the appropriate Level object', function () {
+      const result = M3U8Parser.parseLevelPlaylist(level, 'http://dummy.url.com/playlist.m3u8', 2, 'main', 0);
+      expect(result.fragments).to.have.lengthOf(3);
+      expect(result.fragments[2].baseurl).to.equal('http://dummy.url.com/playlist.m3u8');
+      expect(result.fragments[2].level).to.equal(2);
+      expect(result.fragments[2].type).to.equal('main');
+      expect(result.fragments[2].urlId).to.equal(0);
+      expect(result.fragments[2].relurl).to.equal('https://foo.com/bar/2.ts');
+    });
+    it('Adds `prefetch: true` to prefetch segments', function () {
+      const result = M3U8Parser.parseLevelPlaylist(level, 'http://dummy.url.com/playlist.m3u8', 0);
+      expect(result.fragments[2]).to.have.property('prefetch').which.equals(true);
+    });
+    it('Adds `prefetch: false` to complete segments', function () {
+      const result = M3U8Parser.parseLevelPlaylist(level, 'http://dummy.url.com/playlist.m3u8', 0);
+      expect(result.fragments[0]).to.have.property('prefetch').which.equals(false);
+      expect(result.fragments[1]).to.have.property('prefetch').which.equals(false);
+    });
+    it('Updates `prefetch` to `false` when prefetch segments transform to complete segments', function () {
+      const result1 = M3U8Parser.parseLevelPlaylist(level, 'http://dummy.url.com/playlist.m3u8', 0);
+      const result2 = M3U8Parser.parseLevelPlaylist(levelRefreshed, 'http://dummy.url.com/playlist.m3u8', 0);
+
+      expect(result1.fragments).to.have.lengthOf(3);
+      expect(result1.endSN).to.equal(2);
+      expect(result1.fragments[0].start).to.equal(0);
+      expect(result1.fragments[0].sn).to.equal(0);
+      expect(result1.fragments[1].sn).to.equal(1);
+      expect(result1.fragments[2].sn).to.equal(2);
+      expect(result1.fragments[0].prefetch).to.equal(false);
+      expect(result1.fragments[1].prefetch).to.equal(false);
+      expect(result1.fragments[2].prefetch).to.equal(true);
+      expect(result1.fragments[1].relurl).to.equal('https://foo.com/bar/1.ts');
+      expect(result1.fragments[2].relurl).to.equal('https://foo.com/bar/2.ts');
+
+      expect(result2.fragments).to.have.lengthOf(3);
+      expect(result2.endSN).to.equal(3);
+      expect(result2.fragments[0].start).to.equal(0);
+      expect(result2.fragments[0].sn).to.equal(1);
+      expect(result2.fragments[1].sn).to.equal(2);
+      expect(result2.fragments[2].sn).to.equal(3);
+      expect(result2.fragments[0].prefetch).to.equal(false);
+      expect(result2.fragments[1].prefetch).to.equal(false);
+      expect(result2.fragments[2].prefetch).to.equal(true);
+      expect(result2.fragments[1].relurl).to.equal('https://foo.com/bar/2.ts');
+      expect(result2.fragments[2].relurl).to.equal('https://foo.com/bar/3.ts');
+
+      // Clone the new results that mergeDetails will change
+      const newDetails = JSON.parse(JSON.stringify(result2));
+      mergeDetails(result1, newDetails);
+
+      expect(newDetails.fragments[0].start).to.equal(2);
+    });
+
+    it('Calculates the correct start time, duration and program date time for prefetch segments', function () {
+      const result = M3U8Parser.parseLevelPlaylist(level, 'http://dummy.url.com/playlist.m3u8', 0);
+      const previousPDT = 1536181148531;
+      expect(result.fragments[2].duration).to.equal(2);
+      expect(result.fragments[2].start).to.equal(4);
+      expect(result.fragments[1].programDateTime).to.equal(previousPDT);
+      expect(result.fragments[2].programDateTime).to.equal(previousPDT + 2000);
+    });
+
+    it('Adds "PREFETCH-DIS" to `frag.tagList` and updates discontinuity sequence (cc) tags', function () {
+      const result = M3U8Parser.parseLevelPlaylist(levelWithDiscontinuity, 'http://dummy.url.com/playlist.m3u8', 0);
+      expect(result.fragments[0].cc).to.equal(5);
+      expect(result.fragments[2].cc).to.equal(6);
+      expect(result.fragments[2].tagList).to.have.lengthOf(1);
+      expect(result.fragments[2].tagList[0][0]).to.equal('PREFETCH-DIS');
+    });
+
+    it('Calculates the correct SN, start time and duration for prefetch segments with discontinuity', function () {
+      const result = M3U8Parser.parseLevelPlaylist(levelWithDiscontinuity, 'http://dummy.url.com/playlist.m3u8', 0);
+      const previousPDT = 1536181148531;
+      expect(result.fragments[0].sn).to.equal(100);
+      expect(result.fragments[1].sn).to.equal(101);
+      expect(result.fragments[2].sn).to.equal(102);
+      expect(result.fragments[2].duration).to.equal(2);
+      expect(result.fragments[2].start).to.equal(4);
+      expect(result.fragments[1].programDateTime).to.equal(previousPDT);
+      expect(result.fragments[2].programDateTime).to.equal(previousPDT + 2000);
+    });
   });
 });


### PR DESCRIPTION
### This PR will...
Parse `#EXT-X-PREFETCH` and `#EXT-X-PREFETCH-DISCONTINUITY` manifest tags. 
- Fragments are assigned a `prefetch` property by the m3u8 parser
  - `true` for `#EXT-X-PREFETCH` segments
  - `false` for `#EXTINF` segments
- `cc` is incremented and `["PREFETCH-DIS"]` is added to the `fragment.tagList` when `#EXT-X-PREFETCH-DISCONTINUITY` is encountered

### Why is this Pull Request needed?
To enable HTTP chunked transfer connections to be established before segments are finished encoding (LHLS streaming).