### PR TITLE
[JW8-2676] Remove unnceccessary logging within setCursor

### DIFF
--- a/src/utils/cea-608-parser.js
+++ b/src/utils/cea-608-parser.js
@@ -332,10 +332,8 @@ class Row {
     }
 
     if (this.pos < 0) {
-      logger.log('ERROR', 'Negative cursor position ' + this.pos);
       this.pos = 0;
     } else if (this.pos > NR_COLS) {
-      logger.log('ERROR', 'Too large cursor position ' + this.pos);
       this.pos = NR_COLS;
     }
   }

--- a/src/utils/cea-608-parser.js
+++ b/src/utils/cea-608-parser.js
@@ -332,8 +332,10 @@ class Row {
     }
 
     if (this.pos < 0) {
+      logger.log('DEBUG', 'Negative cursor position ' + this.pos);
       this.pos = 0;
     } else if (this.pos > NR_COLS) {
+      logger.log('DEBUG', 'Too large cursor position ' + this.pos);
       this.pos = NR_COLS;
     }
   }


### PR DESCRIPTION
JW8-2676

### This PR will...

* Remove the two `logger.log()` statements from `setCursor()`

### Why is this Pull Request needed?

* The logs were unnecessary and not indicative of any issues with the stream so they could cause publishers unfounded worry.

### Are there any points in the code the reviewer needs to double check?

* Not in the code, but did I do everything right in the PR? Long time HLS.js lurker, first time contributor.

### Resolves issues:

JW8-2676

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
