### PR TITLE
[JW8-2661] Implement progressive cmaf parsing & typescript controllers

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -137,6 +137,12 @@ class AudioStreamController extends BaseStreamController {
         }
       }
 
+      const trackId = this.trackId;
+      if (!levels || !levels[trackId]) {
+        return;
+      }
+      const levelInfo = levels[trackId];
+
       let media = this.mediaBuffer ? this.mediaBuffer : this.media;
       const videoBuffer = this.videoBuffer ? this.videoBuffer : this.media;
       const bufferInfo = BufferHelper.bufferInfo(media, pos, config.maxBufferHole);
@@ -146,11 +152,10 @@ class AudioStreamController extends BaseStreamController {
       const maxConfigBuffer = Math.min(config.maxBufferLength, config.maxMaxBufferLength);
       const maxBufLen = Math.max(maxConfigBuffer, mainBufferInfo.len);
       const audioSwitch = this.audioSwitch;
-      const trackId = this.trackId;
 
       // if buffer length is less than maxBufLen try to load a new fragment
-      if ((bufferLen < maxBufLen || audioSwitch) && trackId < levels.length) {
-        trackDetails = levels[trackId].details;
+      if (bufferLen < maxBufLen || audioSwitch) {
+        trackDetails = levelInfo.details;
         // if track info not retrieved yet, switch state and wait for track retrieval
         if (typeof trackDetails === 'undefined') {
           this.state = State.WAITING_TRACK;

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -248,6 +248,7 @@ class AudioStreamController extends BaseStreamController {
           const fragState = this.fragmentTracker.getState(frag);
           this.fragCurrent = frag;
           this.startFragRequested = true;
+          let prevPos = this.nextLoadPosition;
           if (Number.isFinite(frag.sn)) {
             this.nextLoadPosition = frag.start + frag.duration;
           }
@@ -259,6 +260,7 @@ class AudioStreamController extends BaseStreamController {
             } else {
               this.log(`Unknown video PTS for continuity counter ${frag.cc}, waiting for video PTS before loading audio frag ${frag.sn} of [${trackDetails.startSN} ,${trackDetails.endSN}],track ${trackId}`);
               this.state = State.WAITING_INIT_PTS;
+              this.nextLoadPosition = prevPos;
             }
           }
         }
@@ -715,7 +717,7 @@ class AudioStreamController extends BaseStreamController {
     }
 
     const track = levels[trackId];
-    LevelHelper.updateFragPTSDTS(track.details, frag, data.startPTS, data.endPTS);
+    LevelHelper.updateFragPTSDTS(track.details, frag, data.startPTS, data.endPTS, data.startDTS, data.endDTS);
     let appendOnBufferFlush = false;
     // Only flush audio from old audio tracks when PTS is known on new audio track
     if (audioSwitch) {

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -192,7 +192,7 @@ class AudioStreamController extends BaseStreamController {
         }
         if (trackDetails.initSegment && !trackDetails.initSegment.data) {
           frag = trackDetails.initSegment;
-        } else if (bufferEnd <= start) {
+        } else if (bufferEnd < start) {
           // If bufferEnd is before the start of the playlist, load the first fragment
           frag = fragments[0];
           if (this.videoTrackCC > -1 && frag.cc !== this.videoTrackCC) {
@@ -449,7 +449,7 @@ class AudioStreamController extends BaseStreamController {
     // If not we need to wait for it
     const initPTS = this.initPTS[cc];
     const initSegmentData = details.initSegment ? details.initSegment.data : [];
-    logger.trace(`Transmuxing ${sn} of [${details.startSN} ,${details.endSN}],track ${trackId}`);
+    // this.log(`Transmuxing ${sn} of [${details.startSN} ,${details.endSN}],track ${trackId}`);
     // time Offset is accurate if level PTS is known, or if playlist is not sliding (not live)
     let accurateTimeOffset = false; // details.PTSKnown || !details.live;
     const transmuxIdentifier = { level: frag.level, sn: frag.sn };
@@ -706,7 +706,7 @@ class AudioStreamController extends BaseStreamController {
       data.endPTS = data.startPTS + frag.duration;
       data.endDTS = data.startDTS + frag.duration;
     }
-    logger.trace(`Parsed ${data.type},PTS:[${data.startPTS.toFixed(3)},${data.endPTS.toFixed(3)}],DTS:[${data.startDTS.toFixed(3)}/${data.endDTS.toFixed(3)}],nb:${data.nb}`);
+    // this.log(`Parsed ${data.type},PTS:[${data.startPTS.toFixed(3)},${data.endPTS.toFixed(3)}],DTS:[${data.startDTS.toFixed(3)}/${data.endDTS.toFixed(3)}],nb:${data.nb}`);
 
     const { audioSwitch, hls, levels, media, pendingData, trackId } = this;
     if (!levels) {

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -617,7 +617,7 @@ class AudioStreamController extends BaseStreamController {
 
   _handleTransmuxComplete (transmuxResult) {
     const id = 'audio';
-    const { hls, levels } = this;
+    const { hls, fragCurrent, levels } = this;
     const { remuxResult, transmuxIdentifier: { level, sn } } = transmuxResult;
 
     // Check if the current fragment has been aborted. We check this by first seeing if we're still playing the current level.
@@ -626,10 +626,13 @@ class AudioStreamController extends BaseStreamController {
     if (!levels) {
       return;
     }
-    const frag = LevelHelper.getFragmentWithSN(levels[level], sn);
+    let frag = LevelHelper.getFragmentWithSN(levels[level], sn);
     if (this._fragLoadAborted(frag)) {
       return;
     }
+    // Assign fragCurrent. References to fragments in the level details change between playlist refreshes.
+    // TODO: Preserve frag references between live playlist refreshes
+    frag = fragCurrent;
 
     this.state = State.PARSING;
     this.pendingBuffering = true;

--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -453,7 +453,7 @@ class AudioStreamController extends BaseStreamController {
     // time Offset is accurate if level PTS is known, or if playlist is not sliding (not live)
     let accurateTimeOffset = false; // details.PTSKnown || !details.live;
     const transmuxIdentifier = { level: frag.level, sn: frag.sn };
-    transmuxer.push(payload, initSegmentData, audioCodec, null, frag, details.totalduration, accurateTimeOffset, initPTS, transmuxIdentifier);
+    transmuxer.push(payload, initSegmentData, audioCodec, '', frag, details.totalduration, accurateTimeOffset, initPTS, transmuxIdentifier);
   }
 
   onBufferReset () {

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -40,7 +40,7 @@ export default class BaseStreamController extends TaskLoop {
   protected startPosition: number = 0;
   protected loadedmetadata: boolean = false;
   protected fragLoadError: number = 0;
-  protected levels: Array<any> = [];
+  protected levels: Array<any> | null = null;
   protected fragmentLoader!: FragmentLoader;
   protected readonly logPrefix: string = '';
 
@@ -150,6 +150,10 @@ export default class BaseStreamController extends TaskLoop {
 
   protected _loadFragForPlayback (frag) {
     const progressCallback: FragmentLoadProgressCallback = (stats, context, payload, networkDetails) => {
+      if (this._fragLoadAborted(frag)) {
+        logger.warn(`Fragment ${frag.sn} of level ${frag.level} was aborted during progressive download.`);
+        return;
+      }
       this._handleFragmentLoadProgress(frag, payload, stats);
     };
     this._doFragLoad(frag, progressCallback)
@@ -224,6 +228,10 @@ export default class BaseStreamController extends TaskLoop {
 
   protected log (msg) {
     logger.log(`${this.logPrefix}: ${msg}`);
+  }
+
+  protected warn (msg) {
+    logger.warn(`${this.logPrefix}: ${msg}`);
   }
 
   set state (nextState) {

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -4,6 +4,9 @@ import { BufferHelper } from '../utils/buffer-helper';
 import { logger } from '../utils/logger';
 import Event from '../events';
 import { ErrorDetails } from '../errors';
+import Fragment from '../loader/fragment';
+import TransmuxerInterface from '../demux/transmuxer-interface';
+import FragmentLoader, { FragLoadSuccessResult, FragmentLoadProgressCallback } from '../loader/fragment-loader';
 
 export const State = {
   STOPPED: 'STOPPED',
@@ -24,11 +27,27 @@ export const State = {
 };
 
 export default class BaseStreamController extends TaskLoop {
-  doTick () {}
+  protected fragPrevious: Fragment | null = null;
+  protected fragCurrent: Fragment | null = null;
+  protected fragmentTracker: any;
+  protected transmuxer: TransmuxerInterface | null = null;
+  protected _state: string = State.STOPPED;
+  protected media?: any;
+  protected mediaBuffer?: any;
+  protected config: any;
+  protected lastCurrentTime: number = 0;
+  protected nextLoadPosition: number = 0;
+  protected startPosition: number = 0;
+  protected loadedmetadata: boolean = false;
+  protected fragLoadError: number = 0;
+  protected levels: Array<any> = [];
+  protected fragmentLoader!: FragmentLoader;
 
-  startLoad () {}
+  protected doTick () {}
 
-  stopLoad () {
+  public startLoad (startPosition: number) : void {}
+
+  public stopLoad () {
     let frag = this.fragCurrent;
     if (frag) {
       if (frag.loader) {
@@ -47,7 +66,7 @@ export default class BaseStreamController extends TaskLoop {
     this.state = State.STOPPED;
   }
 
-  _streamEnded (bufferInfo, levelDetails) {
+  protected _streamEnded (bufferInfo, levelDetails) {
     const { fragCurrent, fragmentTracker } = this;
     // we just got done loading the final fragment and there is no other buffered range after ...
     // rationale is that in case there are any buffered ranges after, it means that there are unbuffered portion in between
@@ -60,7 +79,7 @@ export default class BaseStreamController extends TaskLoop {
     return false;
   }
 
-  onMediaSeeking () {
+  protected onMediaSeeking () {
     const { config, media, mediaBuffer, state } = this;
     const currentTime = media ? media.currentTime : null;
     const bufferInfo = BufferHelper.bufferInfo(mediaBuffer || media, currentTime, this.config.maxBufferHole);
@@ -113,43 +132,46 @@ export default class BaseStreamController extends TaskLoop {
     this.tick();
   }
 
-  onMediaEnded () {
+  protected onMediaEnded () {
     // reset startPosition and lastCurrentTime to restart playback @ stream beginning
     this.startPosition = this.lastCurrentTime = 0;
   }
 
-  onHandlerDestroying () {
+  protected onHandlerDestroying () {
     this.stopLoad();
     super.onHandlerDestroying();
   }
 
-  onHandlerDestroyed () {
+  protected onHandlerDestroyed () {
     this.state = State.STOPPED;
     this.fragmentTracker = null;
   }
 
-  _loadFragForPlayback (frag) {
-    this._doFragLoad(frag)
-      .then((data) => {
+  protected _loadFragForPlayback (frag) {
+    const progressCallback: FragmentLoadProgressCallback = (stats, context, payload, networkDetails) => {
+      this._handleFragmentLoadProgress(frag, payload, stats);
+    };
+    this._doFragLoad(frag, progressCallback)
+      .then((data: FragLoadSuccessResult) => {
         this.fragLoadError = 0;
         if (this._fragLoadAborted(frag)) {
           return;
         }
-        const { payload, stats } = data;
-        logger.log(`Loaded ${frag.sn} of level ${frag.level}`);
+        logger.log(`Loaded fragment ${frag.sn} of level ${frag.level}`);
         // For compatibility, emit the FRAG_LOADED with the same signature
-        data.frag = frag;
-        this.hls.trigger(Event.FRAG_LOADED, data);
-        this._handleFragmentLoad(frag, payload, stats);
+        const compatibilityEventData: any = data;
+        compatibilityEventData.frag = frag;
+        this.hls.trigger(Event.FRAG_LOADED, compatibilityEventData);
+        this._handleFragmentLoadComplete(frag, data.stats);
       });
   }
 
-  _loadInitSegment (frag) {
+  protected _loadInitSegment (frag) {
     this._doFragLoad(frag)
-      .then((data) => {
+      .then((data: FragLoadSuccessResult) => {
         const { stats, payload } = data;
         const { fragCurrent, hls, levels } = this;
-        if (this._fragLoadAborted(frag)) {
+        if (this._fragLoadAborted(frag) || !levels) {
           return;
         }
         this.state = State.IDLE;
@@ -161,14 +183,29 @@ export default class BaseStreamController extends TaskLoop {
       });
   }
 
-  _fragLoadAborted (frag) {
-    return this.state !== State.FRAG_LOADING || frag !== this.fragCurrent;
+  protected _fragLoadAborted (frag) {
+    const { fragCurrent } = this;
+    if (!frag || !fragCurrent) {
+      return true;
+    }
+    const { level, sn } = fragCurrent;
+    return frag.level !== level || frag.sn !== sn;
   }
 
-  _doFragLoad (frag) {
+  protected _handleFragmentLoadComplete (frag, stats) {
+    const { transmuxer } = this;
+    if (!transmuxer) {
+      return;
+    }
+    transmuxer.flush({ level: frag.level, sn: frag.sn });
+  }
+
+  protected _handleFragmentLoadProgress (frag, payload, stats) {}
+
+  protected _doFragLoad (frag, progressCallback?: FragmentLoadProgressCallback) {
     this.state = State.FRAG_LOADING;
     this.hls.trigger(Event.FRAG_LOADING, { frag });
-    return this.fragmentLoader.load(frag)
+    return this.fragmentLoader.load(frag, progressCallback)
       .catch((e) => {
         const errorData = e ? e.data : null;
         if (errorData && errorData.details === ErrorDetails.INTERNAL_ABORTED) {
@@ -185,8 +222,15 @@ export default class BaseStreamController extends TaskLoop {
       });
   }
 
-  _handleFragmentLoadComplete (frag, stats) {
-    const transmuxIdentifier = { level: frag.level, sn: frag.sn };
-    this.transmuxer.flush(transmuxIdentifier);
+  set state (nextState) {
+    if (this.state !== nextState) {
+      const previousState = this.state;
+      this._state = nextState;
+      logger.log(`controller:${previousState}->${nextState}`);
+    }
+  }
+
+  get state () {
+    return this._state;
   }
 }

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -227,7 +227,7 @@ export default class BaseStreamController extends TaskLoop {
     };
 
     // TODO: Allow progressive downloading of encrypted streams after the decrypter can handle progressive decryption
-    if (frag.decryptdata && progressCallback) {
+    if (frag.decryptdata && frag.decryptdata.key && progressCallback) {
       return this.fragmentLoader.load(frag)
         .then((data: FragLoadSuccessResult) => {
           progressCallback(data);

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -159,7 +159,7 @@ export default class BaseStreamController extends TaskLoop {
     this._doFragLoad(frag, progressCallback)
       .then((data: FragLoadSuccessResult) => {
         this.fragLoadError = 0;
-        if (this._fragLoadAborted(frag)) {
+        if (!data || this._fragLoadAborted(frag)) {
           return;
         }
         this.log(`Loaded fragment ${frag.sn} of level ${frag.level}`);
@@ -176,7 +176,7 @@ export default class BaseStreamController extends TaskLoop {
       .then((data: FragLoadSuccessResult) => {
         const { stats, payload } = data;
         const { fragCurrent, hls, levels } = this;
-        if (this._fragLoadAborted(frag) || !levels) {
+        if (!data || this._fragLoadAborted(frag) || !levels) {
           return;
         }
         this.state = State.IDLE;

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -91,10 +91,6 @@ class BufferController extends EventHandler {
     this.hls = hls;
   }
 
-  destroy () {
-    EventHandler.prototype.destroy.call(this);
-  }
-
   onLevelPtsUpdated (data: { type: SourceBufferName, start: number }) {
     let type = data.type;
     let audioTrack = this.tracks.audio;

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1422,6 +1422,8 @@ function _hasDroppedFrames (frag, dropped, startSN) {
       }
     } else {
       logger.warn(`[stream-controller]: Fragment ${frag.sn} of level ${frag.level} already backtracked and will be appended with a gap`);
+      frag.backtracked = false;
+      return false;
     }
   } else {
     // Only reset the backtracked flag if we've loaded the frag without any dropped frames

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1371,7 +1371,7 @@ export default class StreamController extends BaseStreamController {
     if (data.hasVideo === true) {
       frag.addElementaryStream(ElementaryStreamTypes.VIDEO);
     }
-    this.log(`Parsed ${data.type},PTS:[${data.startPTS.toFixed(3)},${data.endPTS.toFixed(3)}],DTS:[${data.startDTS.toFixed(3)}/${data.endDTS.toFixed(3)}],nb:${data.nb},dropped:${data.dropped || 0}`);
+    // this.log(`Parsed ${data.type},PTS:[${data.startPTS.toFixed(3)},${data.endPTS.toFixed(3)}],DTS:[${data.startDTS.toFixed(3)}/${data.endDTS.toFixed(3)}],nb:${data.nb},dropped:${data.dropped || 0}`);
 
     const { hls, level, levels } = this;
     if (!levels) {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1233,13 +1233,16 @@ export default class StreamController extends BaseStreamController {
     }
 
     // Avoid buffering if backtracking this fragment
-    if (_hasDroppedFrames(frag, video ? video.dropped : 0, levels[level].details.startSN)) {
-      this._backtrack(frag, video.startPTS);
-      return;
+    if (video) {
+      if (_hasDroppedFrames(frag, video.dropped, levels[level].details.startSN)) {
+        this._backtrack(frag, video.startPTS);
+        return;
+      } else {
+        this._bufferFragmentData(video);
+      }
     }
 
     this._bufferFragmentData(audio);
-    this._bufferFragmentData(video);
 
     if (id3) {
       id3.frag = frag;

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1175,11 +1175,11 @@ export default class StreamController extends BaseStreamController {
   private _loadBitrateTestFrag (frag) {
     this._doFragLoad(frag)
       .then((data) => {
-        const { stats } = data as FragLoadSuccessResult;
         const { hls } = this;
-        if (hls.nextLoadLevel || this._fragLoadAborted(frag)) {
+        if (!data || hls.nextLoadLevel || this._fragLoadAborted(frag)) {
           return;
         }
+        const { stats } = data as FragLoadSuccessResult;
         this.bitrateTest = false;
         this.fragLoadError = 0;
         this.state = State.IDLE;

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1193,7 +1193,7 @@ export default class StreamController extends BaseStreamController {
 
   private _handleTransmuxComplete (transmuxResult) {
     const id = 'main';
-    const { hls, levels } = this;
+    const { hls, fragCurrent, levels } = this;
     const { remuxResult, transmuxIdentifier: { level, sn } } = transmuxResult;
 
     // Check if the current fragment has been aborted. We check this by first seeing if we're still playing the current level.
@@ -1203,10 +1203,13 @@ export default class StreamController extends BaseStreamController {
       return;
     }
 
-    const frag = LevelHelper.getFragmentWithSN(levels[level], sn);
+    let frag = LevelHelper.getFragmentWithSN(levels[level], sn);
     if (this._fragLoadAborted(frag)) {
       return;
     }
+    // Assign fragCurrent. References to fragments in the level details change between playlist refreshes.
+    // TODO: Preserve frag references between live playlist refreshes
+    frag = fragCurrent;
 
     let { audio, video, text, id3, initSegment } = remuxResult;
     // The audio-stream-controller handles audio buffering if Hls.js is playing an alternate audio track

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -181,6 +181,11 @@ export default class StreamController extends BaseStreamController {
       return;
     }
 
+    if (!levels || !levels[level]) {
+      return;
+    }
+    const levelInfo = levels[level];
+
     // if we have not yet loaded any fragment, start loading from start position
     let pos = 0;
     if (this.loadedmetadata) {
@@ -189,16 +194,9 @@ export default class StreamController extends BaseStreamController {
       pos = this.nextLoadPosition;
     }
 
-    // determine next load level
-
-    if (!levels || !levels[level]) {
-      return;
-    }
-    const levelInfo = levels[level];
+    // compute max Buffer Length that we could get from this load level, based on level bitrate. don't buffer more than 60 MB and more than 30s
     const levelBitrate = levelInfo.bitrate;
     let maxBufLen;
-
-    // compute max Buffer Length that we could get from this load level, based on level bitrate. don't buffer more than 60 MB and more than 30s
     if (levelBitrate) {
       maxBufLen = Math.max(8 * config.maxBufferSize / levelBitrate, config.maxBufferLength);
     } else {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -217,9 +217,7 @@ export default class StreamController extends BaseStreamController {
       return;
     }
 
-    // if buffer length is less than maxBufLen try to load a new fragment ...
-    logger.trace(`Buffer length of ${bufferLen.toFixed(3)} is below max of ${maxBufLen.toFixed(3)}. Checking for more payload.`);
-
+    // if buffer length is less than maxBufLen try to load a new fragment
     // set next load level : this will trigger a playlist load if needed
     this.level = hls.nextLoadLevel = level;
 
@@ -866,7 +864,7 @@ export default class StreamController extends BaseStreamController {
     const audioCodec = this._getAudioCodec(currentLevel);
 
     // transmux the MPEG-TS data to ISO-BMFF segments
-    logger.trace(` ${frag.sn} of [${details.startSN} ,${details.endSN}],level ${frag.level}, cc ${frag.cc}`);
+    // this.log(`Transmuxing ${frag.sn} of [${details.startSN} ,${details.endSN}],level ${frag.level}, cc ${frag.cc}`);
     const transmuxer = this.transmuxer = this.transmuxer ||
           new TransmuxerInterface(this.hls, 'main', this._handleTransmuxComplete.bind(this), this._handleTransmuxerFlush.bind(this));
     const transmuxIdentifier = { level: frag.level, sn: frag.sn };
@@ -1373,7 +1371,7 @@ export default class StreamController extends BaseStreamController {
     if (data.hasVideo === true) {
       frag.addElementaryStream(ElementaryStreamTypes.VIDEO);
     }
-    logger.trace(`Parsed ${data.type},PTS:[${data.startPTS.toFixed(3)},${data.endPTS.toFixed(3)}],DTS:[${data.startDTS.toFixed(3)}/${data.endDTS.toFixed(3)}],nb:${data.nb},dropped:${data.dropped || 0}`);
+    // this.log(`Parsed ${data.type},PTS:[${data.startPTS.toFixed(3)},${data.endPTS.toFixed(3)}],DTS:[${data.startDTS.toFixed(3)}/${data.endDTS.toFixed(3)}],nb:${data.nb},dropped:${data.dropped || 0}`);
 
     const { hls, level, levels } = this;
     if (!levels) {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1371,7 +1371,7 @@ export default class StreamController extends BaseStreamController {
     if (data.hasVideo === true) {
       frag.addElementaryStream(ElementaryStreamTypes.VIDEO);
     }
-    // this.log(`Parsed ${data.type},PTS:[${data.startPTS.toFixed(3)},${data.endPTS.toFixed(3)}],DTS:[${data.startDTS.toFixed(3)}/${data.endDTS.toFixed(3)}],nb:${data.nb},dropped:${data.dropped || 0}`);
+    this.log(`Parsed ${data.type},PTS:[${data.startPTS.toFixed(3)},${data.endPTS.toFixed(3)}],DTS:[${data.startDTS.toFixed(3)}/${data.endDTS.toFixed(3)}],nb:${data.nb},dropped:${data.dropped || 0}`);
 
     const { hls, level, levels } = this;
     if (!levels) {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -7,7 +7,7 @@ import { BufferHelper } from '../utils/buffer-helper';
 import TransmuxerInterface from '../demux/transmuxer-interface';
 import Event from '../events';
 import { FragmentState } from './fragment-tracker';
-import { ElementaryStreamTypes } from '../loader/fragment';
+import Fragment, { ElementaryStreamTypes } from '../loader/fragment';
 import PlaylistLoader from '../loader/playlist-loader';
 import * as LevelHelper from './level-helper';
 import TimeRanges from '../utils/time-ranges';
@@ -17,12 +17,38 @@ import { alignStream } from '../utils/discontinuities';
 import { findFragmentByPDT, findFragmentByPTS } from './fragment-finders';
 import GapController from './gap-controller';
 import BaseStreamController, { State } from './base-stream-controller';
-import FragmentLoader from '../loader/fragment-loader';
+import FragmentLoader, { FragLoadSuccessResult } from '../loader/fragment-loader';
 import { TransmuxIdentifier } from '../types/transmuxer';
+import { LoaderStats } from '../types/loader';
 
 const TICK_INTERVAL = 100; // how often to tick in ms
 
-class StreamController extends BaseStreamController {
+export default class StreamController extends BaseStreamController {
+  private audioCodecSwap: boolean;
+  private bitrateTest: boolean;
+  private gapController: any;
+  private stallReported: boolean;
+  private level: number = -1;
+  private startFragRequested: boolean = false;
+  private forceStartLoad: boolean = false;
+  private retryDate: number = 0;
+  private levelLastLoaded: number | null = null;
+  private altAudio: boolean = false;
+  private fragPlaying: Fragment | null = null;
+  private previouslyPaused: boolean = false;
+  private immediateSwitch: boolean = false;
+  private onvseeking: Function | null = null;
+  private onvseeked: Function | null = null;
+  private onvended: Function | null = null;
+  private fragLastKbps: number = 0;
+  private stalled: boolean = false;
+  private audioCodecSwitch: boolean = false;
+  private stats: LoaderStats | null = null;
+  private pendingBuffering: boolean = false;
+  private appended: boolean = false;
+  private videoBuffer: any | null = null;
+  private _liveSyncPosition: number | null = null;
+
   constructor (hls, fragmentTracker) {
     super(hls,
       Event.MEDIA_ATTACHED,
@@ -48,12 +74,12 @@ class StreamController extends BaseStreamController {
     this.fragmentTracker = fragmentTracker;
     this.gapController = null;
     this.stallReported = false;
-    this._state = State.STOPPED;
+    this.state = State.STOPPED;
     this.stallReported = false;
     this.gapController = null;
   }
 
-  startLoad (startPosition) {
+  startLoad (startPosition): void {
     if (this.levels) {
       const { lastCurrentTime, hls } = this;
       this.stopLoad();
@@ -105,14 +131,15 @@ class StreamController extends BaseStreamController {
     case State.IDLE:
       this._doTickIdle();
       break;
-    case State.WAITING_LEVEL:
-      var level = this.levels[this.level];
-      // check if playlist is already loaded
-      if (level && level.details) {
+    case State.WAITING_LEVEL: {
+      const { levels, level } = this;
+      if (levels && levels[level] && levels[level].details) {
+        // Details is set after the playlist has been loaded
         this.state = State.IDLE;
+        break;
       }
-
       break;
+    }
     case State.FRAG_LOADING_WAITING_RETRY:
       var now = window.performance.now();
       var retryDate = this.retryDate;
@@ -142,14 +169,13 @@ class StreamController extends BaseStreamController {
   // NOTE: Maybe we could rather schedule a check for buffer length after half of the currently
   //       played segment, or on pause/play/seek instead of naively checking every 100ms?
   _doTickIdle () {
-    const hls = this.hls,
-      config = hls.config,
-      media = this.media;
+    const { hls, levelLastLoaded, levels, media } = this;
+    const { config, nextLoadLevel: level } = hls;
 
     // if start level not parsed yet OR
     // if video not attached AND start fragment already requested OR start frag prefetch disable
     // exit loop, as we either need more info (level not parsed) or we need media to be attached to load new fragment
-    if (this.levelLastLoaded === undefined || (
+    if (levelLastLoaded === null || (
       !media && (this.startFragRequested || !config.startFragPrefetch))) {
       return;
     }
@@ -163,15 +189,13 @@ class StreamController extends BaseStreamController {
     }
 
     // determine next load level
-    let level = hls.nextLoadLevel,
-      levelInfo = this.levels[level];
 
-    if (!levelInfo) {
+    if (!levels || !levels[level]) {
       return;
     }
-
-    let levelBitrate = levelInfo.bitrate,
-      maxBufLen;
+    const levelInfo = levels[level];
+    const levelBitrate = levelInfo.bitrate;
+    let maxBufLen;
 
     // compute max Buffer Length that we could get from this load level, based on level bitrate. don't buffer more than 60 MB and more than 30s
     if (levelBitrate) {
@@ -185,8 +209,8 @@ class StreamController extends BaseStreamController {
     // determine next candidate fragment to be loaded, based on current position and end of buffer position
     // ensure up to `config.maxMaxBufferLength` of buffer upfront
 
-    const bufferInfo = BufferHelper.bufferInfo(this.mediaBuffer ? this.mediaBuffer : media, pos, config.maxBufferHole),
-      bufferLen = bufferInfo.len;
+    const bufferInfo = BufferHelper.bufferInfo(this.mediaBuffer ? this.mediaBuffer : media, pos, config.maxBufferHole);
+    let bufferLen = bufferInfo.len;
     // Stay idle if we are still with buffer margins
     if (bufferLen >= maxBufLen) {
       return;
@@ -208,7 +232,7 @@ class StreamController extends BaseStreamController {
     }
 
     if (this._streamEnded(bufferInfo, levelDetails)) {
-      const data = {};
+      const data: any = {};
       if (this.altAudio) {
         data.type = 'video';
       }
@@ -334,7 +358,12 @@ class StreamController extends BaseStreamController {
           // look for a frag sharing the same CC
           if (!frag) {
             frag = BinarySearch.search(fragments, function (frag) {
-              return fragPrevious.cc - frag.cc;
+             if (fragPrevious.cc > frag.cc) {
+               return 1;
+             } else if (fragPrevious < frag.cc) {
+               return -1;
+             }
+             return 0;
             });
             if (frag) {
               logger.log(`live playlist, switching playlist, load frag with same CC: ${frag.sn}`);
@@ -449,19 +478,6 @@ class StreamController extends BaseStreamController {
         this.fragmentTracker.removeFragment(frag);
       }
     }
-  }
-
-  set state (nextState) {
-    if (this.state !== nextState) {
-      const previousState = this.state;
-      this._state = nextState;
-      logger.log(`main stream:${previousState}->${nextState}`);
-      this.hls.trigger(Event.STREAM_STATE_TRANSITION, { previousState, nextState });
-    }
-  }
-
-  get state () {
-    return this._state;
   }
 
   getBufferedFrag (position) {
@@ -601,7 +617,7 @@ class StreamController extends BaseStreamController {
    * we should take into account new segment fetch time
    */
   nextLevelSwitch () {
-    const media = this.media;
+    const { levels, media } = this;
     // ensure that media is defined and that metadata are available (to retrieve currentTime)
     if (media && media.readyState) {
       let fetchdelay, fragPlayingCurrent, nextBufferedFrag;
@@ -611,9 +627,9 @@ class StreamController extends BaseStreamController {
         // minus 1s to avoid video freezing, that could happen if we flush keyframe of current video ...
         this.flushMainBuffer(0, fragPlayingCurrent.startPTS - 1);
       }
-      if (!media.paused) {
+      if (!media.paused && levels) {
         // add a safety delay of 1s
-        let nextLevelId = this.hls.nextLoadLevel, nextLevel = this.levels[nextLevelId], fragLastKbps = this.fragLastKbps;
+        let nextLevelId = this.hls.nextLoadLevel, nextLevel = levels[nextLevelId], fragLastKbps = this.fragLastKbps;
         if (fragLastKbps && this.fragCurrent) {
           fetchdelay = this.fragCurrent.duration * nextLevel.bitrate / (1000 * fragLastKbps) + 1;
         } else {
@@ -647,7 +663,7 @@ class StreamController extends BaseStreamController {
 
   flushMainBuffer (startOffset, endOffset) {
     this.state = State.BUFFER_FLUSHING;
-    let flushScope = { startOffset: startOffset, endOffset: endOffset };
+    let flushScope: any = { startOffset: startOffset, endOffset: endOffset };
     // if alternate audio tracks are used, only flush video, otherwise flush everything
     if (this.altAudio) {
       flushScope.type = 'video';
@@ -695,7 +711,7 @@ class StreamController extends BaseStreamController {
       media.removeEventListener('seeking', this.onvseeking);
       media.removeEventListener('seeked', this.onvseeked);
       media.removeEventListener('ended', this.onvended);
-      this.onvseeking = this.onvseeked = this.onvended = null;
+      this.onvseeking = this.onvseeked = this.onvended = null
     }
     this.media = this.mediaBuffer = null;
     this.loadedmetadata = false;
@@ -751,12 +767,20 @@ class StreamController extends BaseStreamController {
   }
 
   onLevelLoaded (data) {
+    const { levels, levelLastLoaded } = this;
     const newDetails = data.details;
     const newLevelId = data.level;
-    const lastLevel = this.levels[this.levelLastLoaded];
-    const curLevel = this.levels[newLevelId];
+
     const duration = newDetails.totalduration;
     let sliding = 0;
+    let lastLevel;
+    let curLevel;
+    if (levels) {
+      if (levelLastLoaded) {
+        lastLevel = levels[levelLastLoaded];
+      }
+      curLevel = levels[newLevelId];
+    }
 
     logger.log(`level ${newLevelId} loaded [${newDetails.startSN},${newDetails.endSN}], cc [${newDetails.startCC}, ${newDetails.endCC}] duration:${duration}`);
 
@@ -786,7 +810,7 @@ class StreamController extends BaseStreamController {
     this.levelLastLoaded = newLevelId;
     this.hls.trigger(Event.LEVEL_UPDATED, { details: newDetails, level: newLevelId });
 
-    if (this.startFragRequested === false) {
+    if (!this.startFragRequested) {
     // compute start position if set to -1. use it straight away if value is defined
       if (this.startPosition === -1 || this.lastCurrentTime === -1) {
         // first, check if start time offset has been set in playlist, if yes, use this value
@@ -827,14 +851,15 @@ class StreamController extends BaseStreamController {
     }
   }
 
-  _handleFragmentLoad (frag, payload, stats) {
+  _handleFragmentLoadProgress (frag, payload, stats) {
     const { fragCurrent, levels, media } = this;
+    if (!levels || !fragCurrent) {
+      logger.warn('Levels and fragCurrent became undefined during fragment load progress; this chunk will be discarded.');
+      return;
+    }
     const currentLevel = levels[fragCurrent.level];
     const details = currentLevel.details;
     this.stats = stats;
-    this.state = State.PARSING;
-    this.pendingBuffering = true;
-    this.appended = false;
 
     // time Offset is accurate if level PTS is known, or if playlist is not sliding (not live) and if media is not seeking (this is to overcome potential timestamp drifts between playlists and fragments)
     const accurateTimeOffset = !(media && media.seeking) && (details.PTSKnown || !details.live);
@@ -844,7 +869,7 @@ class StreamController extends BaseStreamController {
     // transmux the MPEG-TS data to ISO-BMFF segments
     logger.log(`Parsing ${frag.sn} of [${details.startSN} ,${details.endSN}],level ${frag.level}, cc ${frag.cc}`);
     const transmuxer = this.transmuxer = this.transmuxer ||
-        new TransmuxerInterface(this.hls, 'main', this._handleTransmuxComplete.bind(this), this._handleTransmuxerFlush.bind(this));
+          new TransmuxerInterface(this.hls, 'main', this._handleTransmuxComplete.bind(this), this._handleTransmuxerFlush.bind(this));
     const transmuxIdentifier = { level: frag.level, sn: frag.sn };
     transmuxer.push(
       payload,
@@ -857,7 +882,6 @@ class StreamController extends BaseStreamController {
       null,
       transmuxIdentifier
     );
-    transmuxer.flush(transmuxIdentifier);
   }
 
   _handleFragmentLoadComplete (frag, stats) {
@@ -877,7 +901,7 @@ class StreamController extends BaseStreamController {
         this.mediaBuffer = this.media;
         let fragCurrent = this.fragCurrent;
         // we need to refill audio buffer from main: cancel any frag loading to speed up audio switch
-        if (fragCurrent.loader) {
+        if (fragCurrent && fragCurrent.loader) {
           logger.log('switching to main audio track, cancel main fragment load');
           fragCurrent.loader.abort();
         }
@@ -957,10 +981,14 @@ class StreamController extends BaseStreamController {
         logger.log(`main buffered : ${TimeRanges.toString(media.buffered)}`);
         this.fragPrevious = frag;
         const stats = this.stats;
-        stats.tbuffered = window.performance.now();
-        // we should get rid of this.fragLastKbps
-        this.fragLastKbps = Math.round(8 * stats.total / (stats.tbuffered - stats.tfirst));
-        this.hls.trigger(Event.FRAG_BUFFERED, { stats: stats, frag: frag, id: 'main' });
+        if (!stats) {
+          logger.warn(`Stats object was unset after fragment was buffered. tbuffered will not be recorded for ${this.fragCurrent}`);
+        } else {
+          stats.tbuffered = window.performance.now();
+          // we should get rid of this.fragLastKbps
+          this.fragLastKbps = Math.round(8 * stats.total / (stats.tbuffered - stats.tfirst));
+        }
+        this.hls.trigger(Event.FRAG_BUFFERED, { stats, frag: frag, id: 'main' });
         this.state = State.IDLE;
       }
       this.tick();
@@ -1152,10 +1180,10 @@ class StreamController extends BaseStreamController {
     return audioCodec;
   }
 
-  _loadBitrateTestFrag (frag) {
+  private _loadBitrateTestFrag (frag) {
     this._doFragLoad(frag)
       .then((data) => {
-        const { stats } = data;
+        const { stats } = data as FragLoadSuccessResult;
         const { hls } = this;
         if (hls.nextLoadLevel || this._fragLoadAborted(frag)) {
           return;
@@ -1171,7 +1199,7 @@ class StreamController extends BaseStreamController {
       });
   }
 
-  _handleTransmuxComplete (transmuxResult) {
+  private _handleTransmuxComplete (transmuxResult) {
     const id = 'main';
     const { hls, levels, fragCurrent } = this;
     const { remuxResult, transmuxIdentifier: { level, sn } } = transmuxResult;
@@ -1182,12 +1210,11 @@ class StreamController extends BaseStreamController {
     if (!levels) {
       return;
     }
-
-    let frag = LevelHelper.getFragmentWithSN(levels[level], sn);
-    if (!frag || frag.sn !== this.fragCurrent.sn) {
+    // TODO: Figure out why fragCurrent reference sometimes isn't equal to frag, even when objects look equal
+    const frag = LevelHelper.getFragmentWithSN(levels[level], sn);
+    if (!frag || !fragCurrent || frag.sn !== fragCurrent.sn) {
       return;
     }
-    frag = fragCurrent;
 
     let { audio, video, text, id3, initSegment } = remuxResult;
     // The audio-stream-controller handles audio buffering if Hls.js is playing an alternate audio track
@@ -1198,6 +1225,10 @@ class StreamController extends BaseStreamController {
     // Update timing before a potential backtrack
     this._updateTiming(frag, audio);
     this._updateTiming(frag, video);
+
+    this.state = State.PARSING;
+    this.pendingBuffering = true;
+    this.appended = false;
 
     if (initSegment) {
       if (initSegment.tracks) {
@@ -1215,8 +1246,8 @@ class StreamController extends BaseStreamController {
       return;
     }
 
-    this._bufferFragmentData(frag, audio);
-    this._bufferFragmentData(frag, video);
+    this._bufferFragmentData(audio);
+    this._bufferFragmentData(video);
 
     if (id3) {
       id3.frag = frag;
@@ -1230,21 +1261,31 @@ class StreamController extends BaseStreamController {
     }
   }
 
-  _handleTransmuxerFlush () {
+  private _handleTransmuxerFlush ({ sn, level }) {
+    logger.log(`Parsed main fragment ${sn} of level ${level}.`);
     this._endParsing();
   }
 
-  _endParsing () {
+  private _endParsing () {
     if (this.state !== State.PARSING) {
       return;
     }
-    this.stats.tparsed = window.performance.now();
+    if (this.stats) {
+      this.stats.tparsed = window.performance.now();
+    } else {
+      logger.warn(`Stats object was unset after fragment finished parsing. tparsed will not be recorded for ${this.fragCurrent}`);
+    }
     this.state = State.PARSED;
     this._checkAppendedParsed();
   }
 
-  _bufferInitSegment (frag, tracks) {
+  private _bufferInitSegment (frag, tracks) {
     if (this.state !== State.PARSING) {
+      return;
+    }
+    const { levels, level } = this;
+    if (!levels) {
+      logger.warn(`Levels object was unset while buffering the init segment for fragment ${frag}. The init segment will not be buffered.`);
       return;
     }
     // if audio track is expected to come from audio stream controller, discard any coming from main
@@ -1253,7 +1294,7 @@ class StreamController extends BaseStreamController {
     }
     // include levelCodec in audio and video tracks
     const { audio, video } = tracks;
-    const currentLevel = this.levels[this.level];
+    const currentLevel = levels[level];
     if (audio) {
       let audioCodec = currentLevel.audioCodec;
       const ua = navigator.userAgent.toLowerCase();
@@ -1302,7 +1343,7 @@ class StreamController extends BaseStreamController {
     this.tick();
   }
 
-  _bufferFragmentData (frag, data) {
+  private _bufferFragmentData (data) {
     if (!data || this.state !== State.PARSING) {
       return;
     }
@@ -1321,7 +1362,7 @@ class StreamController extends BaseStreamController {
     this.tick();
   }
 
-  _updateTiming (frag, data) {
+  private _updateTiming (frag, data) {
     if (!data) {
       return;
     }
@@ -1340,12 +1381,16 @@ class StreamController extends BaseStreamController {
     logger.log(`Parsed ${data.type},PTS:[${data.startPTS.toFixed(3)},${data.endPTS.toFixed(3)}],DTS:[${data.startDTS.toFixed(3)}/${data.endDTS.toFixed(3)}],nb:${data.nb},dropped:${data.dropped || 0}`);
 
     const { hls, level, levels } = this;
+    if (!levels) {
+      logger.warn(`Levels object was unset while buffering fragment ${frag}. The current chunk will not be buffered.`);
+      return;
+    }
     const currentLevel = levels[level];
     const drift = LevelHelper.updateFragPTSDTS(currentLevel.details, frag, data.startPTS, data.endPTS, data.startDTS, data.endDTS);
     hls.trigger(Event.LEVEL_PTS_UPDATED, { details: currentLevel.details, level, drift, type: data.type, start: data.startPTS, end: data.endPTS });
   }
 
-  _backtrack (frag, nextLoadPosition) {
+  private _backtrack (frag, nextLoadPosition) {
     // Return back to the IDLE state without appending to buffer
     // Causes findFragments to backtrack a segment and find the keyframe
     // Audio fragments arriving before video sets the nextLoadPosition, causing _findFragments to skip the backtracked fragment
@@ -1387,5 +1432,3 @@ function _hasDroppedFrames (frag, dropped, startSN) {
     return false;
   }
 }
-
-export default StreamController;

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -453,7 +453,7 @@ export default class StreamController extends BaseStreamController {
     this.fragCurrent = frag;
     this.startFragRequested = true;
     // Don't update nextLoadPosition for fragments which are not buffered
-    if (Number.isFinite(frag.sn) && !frag.bitrateTest) {
+    if (Number.isFinite(frag.sn) && !this.bitrateTest) {
       this.nextLoadPosition = frag.start + frag.duration;
     }
 
@@ -465,6 +465,7 @@ export default class StreamController extends BaseStreamController {
         this._loadInitSegment(frag);
       } else if (this.bitrateTest) {
         frag.bitrateTest = true;
+        this.log(`Fragment ${frag.sn} of level ${frag.level} is being downloaded to test bitrate and will not be buffered`);
         this._loadBitrateTestFrag(frag);
       } else {
         this._loadFragForPlayback(frag);
@@ -1180,10 +1181,10 @@ export default class StreamController extends BaseStreamController {
           return;
         }
         const { stats } = data as FragLoadSuccessResult;
-        this.bitrateTest = false;
         this.fragLoadError = 0;
         this.state = State.IDLE;
         this.startFragRequested = false;
+        this.bitrateTest = false;
         frag.bitrateTest = false;
         stats.tparsed = stats.tbuffered = window.performance.now();
         hls.trigger(Event.FRAG_BUFFERED, { stats: stats, frag, id: 'main' });

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -1410,14 +1410,14 @@ function _hasDroppedFrames (frag, dropped, startSN) {
     frag.dropped = dropped;
     if (!frag.backtracked) {
       if (frag.sn === startSN) {
-        this.warn('Missing video frame(s) on first frag, appending with gap', frag.sn);
+        logger.warn(`[stream-controller]:  Fragment ${frag.sn} of level ${frag.level} is missing ${frag.dropped} video frame(s); this is the start fragment and will be appended with a gap`);
         return false;
       } else {
-        this.warn('Missing video frame(s), backtracking fragment', frag.sn);
+        logger.warn(`[stream-controller]: Fragment ${frag.sn} of level ${frag.level} is missing ${frag.dropped} video frame(s); backtracking to find a keyframe`);
         return true;
       }
     } else {
-      this.warn('Already backtracked on this fragment, appending with the gap', frag.sn);
+      logger.warn(`[stream-controller]: Fragment ${frag.sn} of level ${frag.level} already backtracked and will be appended with a gap`);
     }
   } else {
     // Only reset the backtracked flag if we've loaded the frag without any dropped frames

--- a/src/demux/aacdemuxer.ts
+++ b/src/demux/aacdemuxer.ts
@@ -18,7 +18,7 @@ class AACDemuxer extends NonProgressiveDemuxer {
     this.config = config;
   }
 
-  resetInitSegment (initSegment, audioCodec, videoCodec, duration) {
+  resetInitSegment (audioCodec, videoCodec, duration) {
     this._audioTrack = { container: 'audio/adts', type: 'audio', id: 0, sequenceNumber: 0, isAAC: true, samples: [], len: 0, manifestCodec: audioCodec, duration: duration, inputTimeScale: 90000 };
   }
 
@@ -48,7 +48,7 @@ class AACDemuxer extends NonProgressiveDemuxer {
   }
 
   // feed incoming data to the front of the parsing pipeline
-  demuxInternal (data, timeOffset, contiguous, accurateTimeOffset): DemuxerResult {
+  demuxInternal (data, timeOffset): DemuxerResult {
     let track = this._audioTrack;
     let id3Data = ID3.getID3Data(data, 0) || [];
     let timestamp = ID3.getTimeStamp(id3Data);
@@ -90,7 +90,7 @@ class AACDemuxer extends NonProgressiveDemuxer {
     };
   }
 
-  demuxSampleAes (data: Uint8Array, decryptData: Uint8Array, timeOffset: number, contiguous: boolean): Promise<DemuxerResult> {
+  demuxSampleAes (data: Uint8Array, decryptData: Uint8Array, timeOffset: number): Promise<DemuxerResult> {
     return Promise.reject(new Error('The AAC demuxer does not support Sample-AES decryption'));
   }
 

--- a/src/demux/chunk-cache.ts
+++ b/src/demux/chunk-cache.ts
@@ -8,7 +8,13 @@ export default class ChunkCache {
   }
 
   flush (): Uint8Array {
-    const result = concatUint8Arrays(this.chunks, this.dataLength);
+    const { chunks, dataLength } = this;
+    let result;
+    if (chunks.length === 1) {
+      result = chunks[0];
+    } else {
+      result = concatUint8Arrays(chunks, dataLength);
+    }
     this.reset();
     return result;
   }

--- a/src/demux/mp3demuxer.ts
+++ b/src/demux/mp3demuxer.ts
@@ -18,7 +18,7 @@ class MP3Demuxer extends NonProgressiveDemuxer {
     this.config = config;
   }
 
-  resetInitSegment (initSegment, audioCodec, videoCodec, duration) {
+  resetInitSegment (audioCodec, videoCodec, duration) {
     this._audioTrack = { container: 'audio/mpeg', type: 'audio', id: -1, sequenceNumber: 0, isAAC: false, samples: [], len: 0, manifestCodec: audioCodec, duration: duration, inputTimeScale: 90000 };
   }
 
@@ -44,7 +44,7 @@ class MP3Demuxer extends NonProgressiveDemuxer {
   }
 
   // feed incoming data to the front of the parsing pipeline
-  demux (data, timeOffset, contiguous, accurateTimeOffset) {
+  demux (data, timeOffset) {
     let id3Data = ID3.getID3Data(data, 0);
     let timestamp = ID3.getTimeStamp(id3Data);
     let pts = timestamp ? 90 * timestamp : timeOffset * 90000;
@@ -84,7 +84,7 @@ class MP3Demuxer extends NonProgressiveDemuxer {
     };
   }
 
-  demuxSampleAes (data: Uint8Array, decryptData: Uint8Array, timeOffset: number, contiguous: boolean): Promise<DemuxerResult> {
+  demuxSampleAes (data: Uint8Array, decryptData: Uint8Array, timeOffset: number): Promise<DemuxerResult> {
     return Promise.reject(new Error('The MP3 demuxer does not support SAMPLE-AES decryption'));
   }
 

--- a/src/demux/mp4demuxer.ts
+++ b/src/demux/mp4demuxer.ts
@@ -20,7 +20,7 @@ class MP4Demuxer implements Demuxer {
     return findBox({ data: data, start: 0, end: Math.min(data.length, 16384) }, ['moof']).length > 0;
   }
 
-  demux (data, timeOffset, contiguous, accurateTimeOffset): DemuxerResult {
+  demux (data): DemuxerResult {
     // Load all data into the avc track. The CMAF remuxer will look for the data in the samples object; the rest of the fields do not matter
     let avcSamples = data;
     if (this.remainderData) {
@@ -54,7 +54,7 @@ class MP4Demuxer implements Demuxer {
     };
   }
 
-  demuxSampleAes (data: Uint8Array, decryptData: Uint8Array, timeOffset: number, contiguous: boolean): Promise<DemuxerResult> {
+  demuxSampleAes (data: Uint8Array, decryptData: Uint8Array, timeOffset: number): Promise<DemuxerResult> {
     return Promise.reject(new Error('The MP4 demuxer does not support SAMPLE-AES decryption'));
   }
 

--- a/src/demux/non-progressive-demuxer.ts
+++ b/src/demux/non-progressive-demuxer.ts
@@ -7,26 +7,26 @@ export default class NonProgressiveDemuxer implements Demuxer {
   public _isSampleAes: boolean = false;
   static readonly minProbeByteLength: number = 1024; // 1Kb
 
-  demux (data: Uint8Array, timeOffset: number, contiguous: boolean, isSampleAes?: boolean): DemuxerResult {
+  demux (data: Uint8Array, timeOffset: number, isSampleAes?: boolean): DemuxerResult {
     this._isSampleAes = !!isSampleAes;
     this.cache.push(data);
     return dummyDemuxResult();
   }
 
-  flush (timeOffset, contiguous): DemuxerResult {
+  flush (timeOffset): DemuxerResult {
     const { _isSampleAes } = this;
     const data = this.cache.flush();
-    const result = this.demuxInternal(data, timeOffset, contiguous, _isSampleAes);
+    const result = this.demuxInternal(data, timeOffset, _isSampleAes);
     this.reset();
 
     return result;
   }
 
-  resetInitSegment (initSegment: Uint8Array, audioCodec: string, videoCodec: string, duration: number) {
+  resetInitSegment (audioCodec: string, videoCodec: string, duration: number) {
     this.reset();
   }
 
-  demuxSampleAes (data: Uint8Array, decryptData: Uint8Array, timeOffset: number, contiguous: boolean): Promise<DemuxerResult> {
+  demuxSampleAes (data: Uint8Array, decryptData: Uint8Array, timeOffset: number): Promise<DemuxerResult> {
     return Promise.resolve(dummyDemuxResult());
   }
 
@@ -43,8 +43,6 @@ export default class NonProgressiveDemuxer implements Demuxer {
     this._isSampleAes = false;
   }
 }
-
-
 
 const dummyDemuxResult = () : DemuxerResult => ({
   audioTrack: dummyTrack(),

--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -182,11 +182,11 @@ export default class TransmuxerInterface {
         // @ts-ignore
         transmuxResult.then(data => {
           this.onTransmuxComplete(data);
-          this.onFlush();
+          this.onFlush(transmuxIdentifier);
         });
       } else {
         this.onTransmuxComplete(transmuxResult);
-        this.onFlush();
+        this.onFlush(transmuxIdentifier);
       }
     }
   }
@@ -207,7 +207,7 @@ export default class TransmuxerInterface {
       }
 
       case 'flush': {
-        this.onFlush();
+        this.onFlush(data.data);
         break;
       }
 

--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -100,7 +100,7 @@ export default class TransmuxerInterface {
     }
   }
 
-  push (data: Uint8Array, initSegment: any, audioCodec: string, videoCodec: string, frag: Fragment, duration: number, accurateTimeOffset: boolean, defaultInitPTS: number, transmuxIdentifier: TransmuxIdentifier): void {
+  push (data: Uint8Array, initSegment: any, audioCodec: string, videoCodec: string, frag: Fragment, duration: number, accurateTimeOffset: boolean, defaultInitPTS: number | null, transmuxIdentifier: TransmuxIdentifier): void {
     const { currentTransmuxSession, transmuxer, worker } = this;
     const timeOffset = Number.isFinite(frag.startPTS) ? frag.startPTS : frag.start;
     const decryptdata = frag.decryptdata;

--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -116,15 +116,8 @@ export default class TransmuxerInterface {
      const nextSN = !!(lastFrag && (frag.sn === (lastFrag.sn as number + 1)));
      contiguous = !trackSwitch && nextSN;
 
+     logger.log(`[transmuxer-interface, ${frag.type}]: Starting new transmux session fragment ${frag.sn}, of level ${frag.level}; discontinuity: ${discontinuity}, trackSwitch: ${trackSwitch}, contiguous: ${contiguous}`);
      this.currentTransmuxSession = transmuxIdentifier;
-    }
-
-    if (discontinuity) {
-      logger.log(`${this.id}:discontinuity detected`);
-    }
-
-    if (trackSwitch) {
-      logger.log(`${this.id}:switch detected`);
     }
 
     this.frag = frag;

--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -24,6 +24,8 @@ export default class TransmuxerInterface {
   private onTransmuxComplete: Function;
   private onFlush: Function;
 
+  private currentTransmuxSession: TransmuxIdentifier | null = null;
+
   constructor (hls, id, onTransmuxComplete, onFlush) {
     this.hls = hls;
     this.id = id;
@@ -99,13 +101,24 @@ export default class TransmuxerInterface {
   }
 
   push (data: Uint8Array, initSegment: any, audioCodec: string, videoCodec: string, frag: Fragment, duration: number, accurateTimeOffset: boolean, defaultInitPTS: number, transmuxIdentifier: TransmuxIdentifier): void {
+    const { currentTransmuxSession, transmuxer, worker } = this;
     const timeOffset = Number.isFinite(frag.startPTS) ? frag.startPTS : frag.start;
     const decryptdata = frag.decryptdata;
     const lastFrag = this.frag;
-    const discontinuity = !(lastFrag && (frag.cc === lastFrag.cc));
-    const trackSwitch = !(lastFrag && (frag.level === lastFrag.level));
-    const nextSN = lastFrag && (frag.sn === (lastFrag.sn as number + 1));
-    const contiguous = !trackSwitch && nextSN;
+
+    let contiguous = true;
+    let discontinuity = false;
+    let trackSwitch = false;
+
+    if (startingNewTransmuxSession(currentTransmuxSession, transmuxIdentifier)) {
+     discontinuity = !(lastFrag && (frag.cc === lastFrag.cc));
+     trackSwitch = !(lastFrag && (frag.level === lastFrag.level));
+     const nextSN = !!(lastFrag && (frag.sn === (lastFrag.sn as number + 1)));
+     contiguous = !trackSwitch && nextSN;
+
+     this.currentTransmuxSession = transmuxIdentifier;
+    }
+
     if (discontinuity) {
       logger.log(`${this.id}:discontinuity detected`);
     }
@@ -116,7 +129,6 @@ export default class TransmuxerInterface {
 
     this.frag = frag;
     // Frags with sn of 'initSegment' are not transmuxed
-    const { transmuxer, worker } = this;
     if (worker) {
       // post fragment payload as transferable objects for ArrayBuffer (no copy)
       worker.postMessage({
@@ -221,4 +233,11 @@ export default class TransmuxerInterface {
       }
     }
   }
+}
+
+function startingNewTransmuxSession (currentIdentifier: TransmuxIdentifier | null, newIdentifier: TransmuxIdentifier) {
+  if (!currentIdentifier) {
+    return true;
+  }
+  return currentIdentifier.sn !== newIdentifier.sn || currentIdentifier.level !== newIdentifier.level;
 }

--- a/src/demux/transmuxer-worker.ts
+++ b/src/demux/transmuxer-worker.ts
@@ -75,11 +75,11 @@ export default function TransmuxerWorker (self) {
             // @ts-ignore
             transmuxResult.then(data => {
               emitTransmuxComplete(self, data);
-              self.postMessage({ event: 'flush' });
+              self.postMessage({ event: 'flush', data: transmuxResult });
             });
           } else {
             emitTransmuxComplete(self, transmuxResult);
-            self.postMessage({ event: 'flush' });
+            self.postMessage({ event: 'flush', data: transmuxResult });
           }
           break;
         }

--- a/src/demux/transmuxer-worker.ts
+++ b/src/demux/transmuxer-worker.ts
@@ -70,16 +70,17 @@ export default function TransmuxerWorker (self) {
         break;
       }
         case 'flush': {
-          const transmuxResult = self.transmuxer.flush(data.transmuxIdentifier);
+          const id = data.transmuxIdentifier;
+          const transmuxResult = self.transmuxer.flush(id);
           if (transmuxResult.then) {
             // @ts-ignore
             transmuxResult.then(data => {
               emitTransmuxComplete(self, data);
-              self.postMessage({ event: 'flush', data: transmuxResult });
+              self.postMessage({ event: 'flush', data: id });
             });
           } else {
             emitTransmuxComplete(self, transmuxResult);
-            self.postMessage({ event: 'flush', data: transmuxResult });
+            self.postMessage({ event: 'flush', data: id });
           }
           break;
         }

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -46,13 +46,6 @@ muxConfig.forEach(({ demux }) => {
   minProbeByteLength = Math.max(minProbeByteLength, demux.minProbeByteLength);
 });
 
-interface TransmuxSession {
-  contiguous: boolean
-  timeOffset: number
-  accurateTimeOffset: boolean
-  identifier: TransmuxIdentifier
-}
-
 class Transmuxer {
   private observer: any;
   private typeSupported: any;
@@ -64,7 +57,6 @@ class Transmuxer {
   private probe!: Function;
   private decryptionPromise: Promise<TransmuxerResult> | null = null;
 
-  private contiguous: boolean = false;
   private timeOffset: number = 0;
   private accurateTimeOffset: boolean = false;
 

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -144,12 +144,11 @@ class Transmuxer {
     }
 
     if (discontinuity || trackSwitch) {
-      demuxer.resetInitSegment(uintInitSegment, audioCodec, videoCodec, duration);
-      remuxer.resetInitSegment(uintInitSegment, audioCodec, videoCodec);
+      this.resetInitSegment(uintInitSegment, audioCodec, videoCodec, duration);
     }
+
     if (discontinuity) {
-      demuxer.resetTimeStamp(defaultInitPTS);
-      remuxer.resetTimeStamp(defaultInitPTS);
+      this.resetTimeStamp(defaultInitPTS);
     }
 
    let result;
@@ -182,6 +181,24 @@ class Transmuxer {
         remuxResult: this.remuxer!.remux(audioTrack, avcTrack, id3Track, textTrack, this.timeOffset, this.contiguous, this.accurateTimeOffset),
         transmuxIdentifier
     }
+  }
+
+  resetInitSegment (initSegment: Uint8Array, audioCodec: string, videoCodec: string, duration: number) {
+    const { demuxer, remuxer } = this;
+    if (!demuxer || !remuxer) {
+      return;
+    }
+    demuxer.resetInitSegment(initSegment, audioCodec, videoCodec, duration);
+    remuxer.resetInitSegment(initSegment, audioCodec, videoCodec);
+  }
+
+  resetTimeStamp (defaultInitPTS) {
+    const { demuxer, remuxer } = this;
+    if (!demuxer || !remuxer) {
+      return;
+    }
+    demuxer.resetTimeStamp(defaultInitPTS);
+    remuxer.resetTimeStamp(defaultInitPTS);
   }
 
   destroy (): void {

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -275,7 +275,7 @@ class Transmuxer {
         demuxer = this.demuxer = new mux.demux(observer, config, typeSupported);
 
         // Ensure that muxers are always initialized with an initSegment
-        demuxer.resetInitSegment(initSegmentData, audioCodec, videoCodec, duration);
+        demuxer.resetInitSegment(audioCodec, videoCodec, duration);
         remuxer.resetInitSegment(initSegmentData, audioCodec, videoCodec);
         logger.log(`[transmuxer.ts]: Probe succeeded with a data length of ${data.length}.`);
         this.probe = probe;

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -81,7 +81,7 @@ class Transmuxer {
     contiguous: boolean,
     duration: number,
     accurateTimeOffset: boolean,
-    defaultInitPTS: number,
+    defaultInitPTS: number | null,
     transmuxIdentifier: TransmuxIdentifier
   ): TransmuxerResult | Promise<TransmuxerResult> {
     let uintData = new Uint8Array(data);

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -302,12 +302,4 @@ function getEncryptionType (data: Uint8Array, decryptData: any): string | null {
   return encryptionType;
 }
 
-function startingNewTransmuxSession (currentSession: TransmuxSession | null, newIdentifier: TransmuxIdentifier) {
-  if (!currentSession) {
-    return true;
-  }
-  const currentId = currentSession.identifier;
-  return currentId.sn !== newIdentifier.sn || currentId.level !== newIdentifier.level;
-}
-
 export default Transmuxer;

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -41,7 +41,6 @@ class TSDemuxer extends NonProgressiveDemuxer {
 
   private sampleAes: any = null;
   private pmtParsed: boolean = false;
-  private contiguous: boolean = false;
   private audioCodec!: string;
   private videoCodec!: string;
   private _duration: number = 0;
@@ -572,10 +571,11 @@ class TSDemuxer extends NonProgressiveDemuxer {
       // only push AVC sample if starting with a keyframe is not mandatory OR
       //    if keyframe already found in this fragment OR
       //       keyframe found in last fragment (track.sps) AND
-      //          samples already appended (we already found a keyframe in this fragment) OR fragment is contiguous
+      //          samples already appended (we already found a keyframe in this fragment)
+      // TODO: The contiguous flag was removed; does it need replacing?
       if (!this.config.forceKeyFrameOnDiscontinuity ||
           avcSample.key === true ||
-          (avcTrack.sps && (nbSamples || this.contiguous))) {
+          (avcTrack.sps && nbSamples)) {
         avcSample.id = nbSamples;
         samples.push(avcSample);
       } else {

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -124,8 +124,8 @@ class TSDemuxer extends NonProgressiveDemuxer {
    * @param {string} videoCodec
    * @param {number} duration (in TS timescale = 90kHz)
    */
-  resetInitSegment (initSegment, audioCodec, videoCodec, duration) {
-    super.resetInitSegment(initSegment, audioCodec, videoCodec, duration);
+  resetInitSegment (audioCodec, videoCodec, duration) {
+    super.resetInitSegment(audioCodec, videoCodec, duration);
 
     this.pmtParsed = false;
     this._pmtId = -1;
@@ -152,11 +152,10 @@ class TSDemuxer extends NonProgressiveDemuxer {
   resetTimeStamp () {}
 
   // feed incoming data to the front of the parsing pipeline
-  demuxInternal (data, contiguous, timeOffset, isSampleAes = false): DemuxerResult {
+  demuxInternal (data, timeOffset, isSampleAes = false): DemuxerResult {
     if (!isSampleAes) {
       this.sampleAes = null;
     }
-    this.contiguous = contiguous;
     let start;
     let stt;
     let pid;
@@ -346,8 +345,8 @@ class TSDemuxer extends NonProgressiveDemuxer {
     };
   }
 
-  demuxSampleAes (data, decryptData, timeOffset, contiguous): Promise <DemuxerResult> {
-    const demuxResult = this.demux(data, contiguous, timeOffset, true);
+  demuxSampleAes (data, decryptData, timeOffset): Promise <DemuxerResult> {
+    const demuxResult = this.demux(data, timeOffset, true);
     const sampleAes = this.sampleAes = new SampleAesDecrypter(this.observer, this.config, decryptData, this.discardEPB);
     return new Promise((resolve, reject) => {
       this.decrypt(demuxResult.audioTrack, demuxResult.avcTrack, sampleAes)

--- a/src/event-handler.ts
+++ b/src/event-handler.ts
@@ -15,9 +15,9 @@ const FORBIDDEN_EVENT_NAMES = {
 };
 
 class EventHandler {
-  hls: any;
-  handledEvents: any[];
-  useGenericHandler: boolean;
+  protected hls: any;
+  private handledEvents: any[];
+  private useGenericHandler: boolean;
 
   constructor (hls: any, ...events: any[]) {
     this.hls = hls;
@@ -28,20 +28,20 @@ class EventHandler {
     this.registerListeners();
   }
 
-  destroy () {
+  protected destroy () {
     this.onHandlerDestroying();
     this.unregisterListeners();
     this.onHandlerDestroyed();
   }
 
-  onHandlerDestroying () {}
-  onHandlerDestroyed () {}
+  protected onHandlerDestroying () {}
+  protected onHandlerDestroyed () {}
 
-  isEventHandler () {
+  private isEventHandler () {
     return typeof this.handledEvents === 'object' && this.handledEvents.length && typeof this.onEvent === 'function';
   }
 
-  registerListeners () {
+  private registerListeners () {
     if (this.isEventHandler()) {
       this.handledEvents.forEach(function (event) {
         if (FORBIDDEN_EVENT_NAMES[event]) {
@@ -53,7 +53,7 @@ class EventHandler {
     }
   }
 
-  unregisterListeners () {
+  private unregisterListeners () {
     if (this.isEventHandler()) {
       this.handledEvents.forEach(function (event) {
         this.hls.off(event, this.onEvent);
@@ -64,11 +64,11 @@ class EventHandler {
   /**
    * arguments: event (string), data (any)
    */
-  onEvent (event: string, data: any) {
+  private onEvent (event: string, data: any) {
     this.onEventGeneric(event, data);
   }
 
-  onEventGeneric (event: string, data: any) {
+  private onEventGeneric (event: string, data: any) {
     let eventToFunction = function (event: string, data: any) {
       let funcName = 'on' + event.replace('hls', '');
       if (typeof this[funcName] !== 'function') {

--- a/src/events.js
+++ b/src/events.js
@@ -110,9 +110,7 @@ const HlsEvents = {
   // fired when a decrypt key loading starts - data: { frag : fragment object }
   KEY_LOADING: 'hlsKeyLoading',
   // fired when a decrypt key loading is completed - data: { frag : fragment object, payload : key payload, stats : { trequest, tfirst, tload, length } }
-  KEY_LOADED: 'hlsKeyLoaded',
-  // fired upon stream controller state transitions - data: { previousState, nextState }
-  STREAM_STATE_TRANSITION: 'hlsStreamStateTransition'
+  KEY_LOADED: 'hlsKeyLoaded'
 };
 
 export default HlsEvents;

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -104,7 +104,11 @@ export default class FragmentLoader {
           },
           onProgress: (stats, context, data, networkDetails) => {
             if (onProgress) {
-              onProgress(stats, context, data as ArrayBuffer, networkDetails);
+              onProgress({
+                payload: data as ArrayBuffer,
+                stats,
+                networkDetails
+              });
             }
           }
       };
@@ -140,4 +144,4 @@ export interface FragLoadFailResult {
   networkDetails: XMLHttpRequest
 }
 
-export type FragmentLoadProgressCallback = (stats: LoaderStats, context: LoaderContext, data: ArrayBuffer, networkDetails?: XMLHttpRequest) => void;
+export type FragmentLoadProgressCallback = (result: FragLoadSuccessResult) => void;

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -17,7 +17,7 @@ export default class FragmentLoader {
     this.config = config;
   }
 
-  load (frag: Fragment): Promise<FragLoadSuccessResult | LoadError> {
+  load (frag: Fragment, onProgress?: FragmentLoadProgressCallback): Promise<FragLoadSuccessResult | LoadError> {
     if (!frag.url) {
       return Promise.reject(new LoadError(null, 'Fragment does not have a url'));
     }
@@ -102,7 +102,11 @@ export default class FragmentLoader {
                   networkDetails
               }));
           },
-          onProgress: (stats, context, data, networkDetails) => {}
+          onProgress: (stats, context, data, networkDetails) => {
+            if (onProgress) {
+              onProgress(stats, context, data as ArrayBuffer, networkDetails);
+            }
+          }
       };
       loader.load(loaderContext, loaderConfig, callbacks);
     });
@@ -135,3 +139,5 @@ export interface FragLoadFailResult {
   frag: Fragment
   networkDetails: XMLHttpRequest
 }
+
+export type FragmentLoadProgressCallback = (stats: LoaderStats, context: LoaderContext, data: ArrayBuffer, networkDetails?: XMLHttpRequest) => void;

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -59,6 +59,8 @@ export default class Fragment {
   public startPTS!: number;
   // The start time of the fragment, as listed in the manifest. Updated after transmuxing.
   public start: number = 0;
+  // Set when the fragment was loaded and transmuxed, but was stopped from buffering due to dropped frames.
+  public backtracked: boolean = false;
   // LHLS prefetch flag
   public prefetch?: boolean;
 

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -55,8 +55,14 @@ export default class Fragment {
   public level: number = -1;
   // The continuity counter of the fragment
   public cc: number = 0;
-  // The starting Presentation Time Stamp(PTS) of the fragment. Updated after transmuxing.
+  // The starting Presentation Time Stamp (PTS) of the fragment. Updated after transmuxing.
   public startPTS!: number;
+  // The ending Presentation Time Stamp (PTS) of the fragment. Updated after transmuxing.
+  public endPTS!: number;
+  // The starting Decode Time Stamp (DTS) of the fragment. Updated after transmuxing.
+  public startDTS!: number;
+  // The ending Decode Time Stamp (DTS) of the fragment. Updated after transmuxing.
+  public endDTS!: number;
   // The start time of the fragment, as listed in the manifest. Updated after transmuxing.
   public start: number = 0;
   // Set when the fragment was loaded and transmuxed, but was stopped from buffering due to dropped frames.

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -1,6 +1,7 @@
 import { InitSegmentData, RemuxedTrack, Remuxer, RemuxerResult } from '../types/remuxer';
 import { getDuration, getStartDTS, offsetStartDTS, parseInitSegment } from '../utils/mp4-tools';
 import { TrackSet } from '../types/track';
+import { logger } from '../utils/logger';
 
 class PassThroughRemuxer implements Remuxer {
   private emitInitSegment: boolean = false;
@@ -9,12 +10,14 @@ class PassThroughRemuxer implements Remuxer {
   private initData?: any;
   private initPTS?: number;
   private initTracks?: TrackSet;
+  private lastEndDTS?: number;
 
   destroy () {
   }
 
   resetTimeStamp (defaultInitPTS) {
     this.initPTS = defaultInitPTS;
+    this.lastEndDTS = undefined;
   }
 
   resetInitSegment (initSegment, audioCodec, videoCodec) {
@@ -62,42 +65,56 @@ class PassThroughRemuxer implements Remuxer {
     this.initTracks = tracks;
   }
 
+  // TODO: Handle unsignaled discontinuities; contiguous and accurateTimeOffset flags are currently unused
   remux (audioTrack, videoTrack, id3Track, textTrack, timeOffset, contiguous, accurateTimeOffset): RemuxerResult {
+    let { initPTS, lastEndDTS } = this;
+    const result: RemuxerResult =  {
+      audio: undefined,
+      video: undefined,
+      text: textTrack,
+      id3: id3Track,
+      initSegment: undefined
+    };
+
+    // If we haven't yet set a lastEndDTS, or it was reset, set it to the provided timeOffset. We want to use the
+    // lastEndDTS over timeOffset whenever possible; during progressive playback, the media source will not update
+    // the media duration (which is what timeOffset is provided as) before we need to process the next chunk.
+    if (!Number.isFinite(lastEndDTS)) {
+      lastEndDTS = this.lastEndDTS = timeOffset || 0;
+    }
+
     // The binary segment data is added to the videoTrack in the mp4demuxer. We don't check to see if the data is only
     // audio or video (or both); adding it to video was an arbitrary choice.
     const data = videoTrack.samples;
     if (!data || !data.length) {
-      return {
-          audio: undefined,
-          video: undefined,
-          text: textTrack,
-          id3: id3Track,
-          initSegment: undefined
-      };
+      return result;
     }
 
     const initSegment: InitSegmentData = {};
     let initData = this.initData;
-    if (!initData) {
+    if (!initData || !initData.length) {
         this.generateInitSegment(data);
         initData = this.initData;
+    }
+    if (!initData.length) {
+      // We can't remux if the initSegment could not be generated
+      logger.warn('[passthrough-remuxer.ts]: Failed to generate initSegment.');
+      return result;
     }
     if (this.emitInitSegment) {
         initSegment.tracks = this.initTracks;
         this.emitInitSegment = false;
     }
 
-    let startDTS = timeOffset;
-    let initPTS = this.initPTS;
     if (!Number.isFinite(initPTS as number)) {
-        let startDTS = getStartDTS(initData, data);
-        this.initPTS = initPTS = startDTS - timeOffset;
-        initSegment.initPTS = initPTS;
+        this.initPTS = initSegment.initPTS = initPTS = computeInitPTS(initData, data, timeOffset);
     }
-    offsetStartDTS(initData, data, initPTS);
 
     const duration = getDuration(data, initData);
+    const startDTS = lastEndDTS as number;
     const endDTS = duration + startDTS;
+    offsetStartDTS(initData, data, initPTS);
+    this.lastEndDTS = endDTS;
 
     const track: RemuxedTrack = {
         data1: data,
@@ -120,14 +137,16 @@ class PassThroughRemuxer implements Remuxer {
         track.type += 'video';
     }
 
-    return {
-      audio: track.type === 'audio' ? track : undefined,
-      video: track.type !== 'audio' ? track : undefined,
-      text: textTrack,
-      id3: id3Track,
-      initSegment
-    };
+    result.audio = track.type === 'audio' ? track : undefined;
+    result.video = track.type !== 'audio' ? track : undefined;
+    result.text = textTrack;
+    result.id3 = id3Track;
+    result.initSegment = initSegment;
+
+    return result;
   }
 }
+
+const computeInitPTS = (initData, data, timeOffset) => getStartDTS(initData, data) - timeOffset;
 
 export default PassThroughRemuxer;

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -10,14 +10,18 @@ class PassThroughRemuxer implements Remuxer {
   private initData?: any;
   private initPTS?: number;
   private initTracks?: TrackSet;
-  private lastEndDTS?: number;
+  private lastEndDTS: number | null = null;
 
   destroy () {
   }
 
   resetTimeStamp (defaultInitPTS) {
     this.initPTS = defaultInitPTS;
-    this.lastEndDTS = undefined;
+    this.lastEndDTS = null;
+  }
+
+  resetNextTimestamp () {
+    this.lastEndDTS = null;
   }
 
   resetInitSegment (initSegment, audioCodec, videoCodec) {
@@ -66,7 +70,7 @@ class PassThroughRemuxer implements Remuxer {
   }
 
   // TODO: utilize accurateTimeOffset
-  remux (audioTrack, videoTrack, id3Track, textTrack, timeOffset, contiguous, accurateTimeOffset): RemuxerResult {
+  remux (audioTrack, videoTrack, id3Track, textTrack, timeOffset, accurateTimeOffset): RemuxerResult {
     let { initPTS, lastEndDTS } = this;
     const result: RemuxerResult =  {
       audio: undefined,
@@ -79,7 +83,7 @@ class PassThroughRemuxer implements Remuxer {
     // If we haven't yet set a lastEndDTS, or it was reset, set it to the provided timeOffset. We want to use the
     // lastEndDTS over timeOffset whenever possible; during progressive playback, the media source will not update
     // the media duration (which is what timeOffset is provided as) before we need to process the next chunk.
-    if (!Number.isFinite(lastEndDTS) || !contiguous) {
+    if (!Number.isFinite(lastEndDTS)) {
       lastEndDTS = this.lastEndDTS = timeOffset || 0;
     }
 

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -83,7 +83,7 @@ class PassThroughRemuxer implements Remuxer {
     // If we haven't yet set a lastEndDTS, or it was reset, set it to the provided timeOffset. We want to use the
     // lastEndDTS over timeOffset whenever possible; during progressive playback, the media source will not update
     // the media duration (which is what timeOffset is provided as) before we need to process the next chunk.
-    if (!Number.isFinite(lastEndDTS)) {
+    if (!Number.isFinite(lastEndDTS!)) {
       lastEndDTS = this.lastEndDTS = timeOffset || 0;
     }
 

--- a/src/remux/passthrough-remuxer.ts
+++ b/src/remux/passthrough-remuxer.ts
@@ -65,7 +65,7 @@ class PassThroughRemuxer implements Remuxer {
     this.initTracks = tracks;
   }
 
-  // TODO: Handle unsignaled discontinuities; contiguous and accurateTimeOffset flags are currently unused
+  // TODO: utilize accurateTimeOffset
   remux (audioTrack, videoTrack, id3Track, textTrack, timeOffset, contiguous, accurateTimeOffset): RemuxerResult {
     let { initPTS, lastEndDTS } = this;
     const result: RemuxerResult =  {
@@ -79,7 +79,7 @@ class PassThroughRemuxer implements Remuxer {
     // If we haven't yet set a lastEndDTS, or it was reset, set it to the provided timeOffset. We want to use the
     // lastEndDTS over timeOffset whenever possible; during progressive playback, the media source will not update
     // the media duration (which is what timeOffset is provided as) before we need to process the next chunk.
-    if (!Number.isFinite(lastEndDTS)) {
+    if (!Number.isFinite(lastEndDTS) || !contiguous) {
       lastEndDTS = this.lastEndDTS = timeOffset || 0;
     }
 

--- a/src/task-loop.ts
+++ b/src/task-loop.ts
@@ -30,19 +30,20 @@ import EventHandler from './event-handler';
  */
 
 export default class TaskLoop extends EventHandler {
+  private _tickInterval: any | null = null;
+  private _tickTimer: any | null = null;
+  private _tickCallCount: number = 0;
+  private readonly _boundTick: Function;
+
   constructor (hls, ...events) {
     super(hls, ...events);
-
-    this._tickInterval = null;
-    this._tickTimer = null;
-    this._tickCallCount = 0;
     this._boundTick = this.tick.bind(this);
   }
 
   /**
    * @override
    */
-  onHandlerDestroying () {
+  protected onHandlerDestroying () {
     // clear all timers before unregistering from event bus
     this.clearNextTick();
     this.clearInterval();
@@ -51,22 +52,15 @@ export default class TaskLoop extends EventHandler {
   /**
    * @returns {boolean}
    */
-  hasInterval () {
+  protected hasInterval () {
     return !!this._tickInterval;
-  }
-
-  /**
-   * @returns {boolean}
-   */
-  hasNextTick () {
-    return !!this._tickTimer;
   }
 
   /**
    * @param {number} millis Interval time (ms)
    * @returns {boolean} True when interval has been scheduled, false when already scheduled (no effect)
    */
-  setInterval (millis) {
+  protected setInterval (millis) {
     if (!this._tickInterval) {
       this._tickInterval = setInterval(this._boundTick, millis);
       return true;
@@ -77,7 +71,7 @@ export default class TaskLoop extends EventHandler {
   /**
    * @returns {boolean} True when interval was cleared, false when none was set (no effect)
    */
-  clearInterval () {
+  protected clearInterval () {
     if (this._tickInterval) {
       clearInterval(this._tickInterval);
       this._tickInterval = null;
@@ -89,7 +83,7 @@ export default class TaskLoop extends EventHandler {
   /**
    * @returns {boolean} True when timeout was cleared, false when none was set (no effect)
    */
-  clearNextTick () {
+  protected clearNextTick () {
     if (this._tickTimer) {
       clearTimeout(this._tickTimer);
       this._tickTimer = null;
@@ -103,7 +97,7 @@ export default class TaskLoop extends EventHandler {
    * or in the next one (via setTimeout(,0)) in case it has already been called
    * in this tick (in case this is a re-entrant call).
    */
-  tick () {
+  protected tick () {
     this._tickCallCount++;
     if (this._tickCallCount === 1) {
       this.doTick();
@@ -122,5 +116,5 @@ export default class TaskLoop extends EventHandler {
    * For subclass to implement task logic
    * @abstract
    */
-  doTick () {}
+  protected doTick (): void {}
 }

--- a/src/types/demuxer.ts
+++ b/src/types/demuxer.ts
@@ -1,9 +1,9 @@
 export interface Demuxer {
-  demux (data: Uint8Array, timeOffset: number, contiguous: boolean, isSampleAes?: boolean) : DemuxerResult
-  demuxSampleAes (data: Uint8Array, decryptData: Uint8Array, timeOffset: number, contiguous: boolean) : Promise<DemuxerResult>
-  flush(timeOffset?: number, contiguous?: boolean): DemuxerResult
+  demux (data: Uint8Array, timeOffset: number, isSampleAes?: boolean) : DemuxerResult
+  demuxSampleAes (data: Uint8Array, decryptData: Uint8Array, timeOffset: number) : Promise<DemuxerResult>
+  flush(timeOffset?: number): DemuxerResult
   destroy() : void
-  resetInitSegment(initSegment: Uint8Array, audioCodec: string, videoCodec: string, duration: number);
+  resetInitSegment(audioCodec: string, videoCodec: string, duration: number);
   resetTimeStamp(defaultInitPTS?: number | null): void;
 }
 

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -45,9 +45,9 @@ export interface LoaderStats {
   tload: number
   // performance.now() on parse completion
   tparsed: number
-  // number of loaded bytes
-  tbuffered: number
   // performance.now() on fragment buffered
+  tbuffered: number
+  // number of loaded bytes
   loaded: number
   // total number of bytes
   total: number,

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -46,6 +46,8 @@ export interface LoaderStats {
   // performance.now() on parse completion
   tparsed: number
   // number of loaded bytes
+  tbuffered: number
+  // performance.now() on fragment buffered
   loaded: number
   // total number of bytes
   total: number,

--- a/src/types/remuxer.ts
+++ b/src/types/remuxer.ts
@@ -7,11 +7,11 @@ export interface Remuxer {
         id3Track: DemuxedTrack,
         textTrack: DemuxedTrack,
         timeOffset: number,
-        contiguous: boolean,
         accurateTimeOffset: boolean
   ): RemuxerResult
   resetInitSegment(initSegment: Uint8Array, audioCodec: string, videoCodec: string): void
   resetTimeStamp(defaultInitPTS): void
+  resetNextTimestamp() : void
   destroy() : void
 }
 

--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -32,6 +32,7 @@ class FetchLoader implements Loader<LoaderContext> {
       tload: 0,
       loaded: 0,
       tparsed: 0,
+      tbuffered: 0,
       total: 0,
       retry: 0,
       aborted: false

--- a/src/utils/mp4-tools.ts
+++ b/src/utils/mp4-tools.ts
@@ -356,12 +356,10 @@ export function segmentValidRange (data: Uint8Array): SegmentedRange {
     segmentedRange.remainder = data;
     return segmentedRange;
   }
-  // debugger;
-  const first = moofs[0];
   const last = moofs[moofs.length - 1];
-  const lastLast = moofs[moofs.length - 2];
-  segmentedRange.valid = data.slice(0, lastLast.end);
-  segmentedRange.remainder = data.slice(lastLast.end);
+  // Offset by 8 bytes; findBox offsets the start by as much
+  segmentedRange.valid = data.slice(0, last.start - 8);
+  segmentedRange.remainder = data.slice(last.start - 8);
   return segmentedRange;
 }
 
@@ -370,9 +368,9 @@ export interface SegmentedRange {
   remainder: Uint8Array,
 }
 
-export function prependUint8Array (data: Uint8Array, remainderData: Uint8Array) : Uint8Array {
-    const temp = new Uint8Array(data.length + remainderData.length);
-    temp.set(remainderData);
-    temp.set(data, remainderData.length);
+export function appendUint8Array (data1: Uint8Array, data2: Uint8Array) : Uint8Array {
+    const temp = new Uint8Array(data1.length + data2.length);
+    temp.set(data1);
+    temp.set(data2, data1.length);
     return temp;
 }

--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -22,6 +22,7 @@ class XhrLoader implements Loader<LoaderContext> {
       tload: 0,
       loaded: 0,
       tparsed: 0,
+      tbuffered: 0,
       total: 0,
       retry: 0,
       aborted: false

--- a/tests/test-streams.js
+++ b/tests/test-streams.js
@@ -183,5 +183,10 @@ module.exports = {
   altAudioAndTracks: {
     url: 'https://wowzaec2demo.streamlock.net/vod-multitrack/_definst_/smil:ElephantsDream/elephantsdream2.smil/playlist.m3u',
     description: 'Alternate audio tracks, and multiple VTT tracks'
+  },
+  akamaiLhlsCmaf: {
+    url: 'https://cmafref.akamaized.net/cmaf/live/2003074/akamai/master.m3u8',
+    description: 'Akamai LHLS stream via LL-CMAF',
+    live: true
   }
 };

--- a/tests/unit/controller/stream-controller.js
+++ b/tests/unit/controller/stream-controller.js
@@ -43,21 +43,6 @@ describe('StreamController', function () {
       assertStreamControllerStopped(streamController);
     });
 
-    it('should trigger STREAM_STATE_TRANSITION when state is updated', function () {
-      const spy = sinon.spy();
-      hls.on(Event.STREAM_STATE_TRANSITION, spy);
-      streamController.state = State.ENDED;
-      expect(spy.args[0][1]).to.deep.equal({ previousState: State.STOPPED, nextState: State.ENDED });
-    });
-
-    it('should not trigger STREAM_STATE_TRANSITION when state is not updated', function () {
-      const spy = sinon.spy();
-      hls.on(Event.STREAM_STATE_TRANSITION, spy);
-      // no update
-      streamController.state = State.STOPPED;
-      expect(spy.called).to.be.false;
-    });
-
     it('should not start when controller does not have level data', function () {
       streamController.startLoad(1);
       assertStreamControllerStopped(streamController);
@@ -241,7 +226,7 @@ describe('StreamController', function () {
       streamController.media.buffered.length = 0;
       streamController._checkBuffer();
       expect(seekStub).to.have.not.been.called;
-      expect(streamController.loadedmetadata).to.not.exist;
+      expect(streamController.loadedmetadata).to.be.false;
     });
 
     it('should complete the immediate switch if signalled', function () {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,6 @@ const lightPlugins = [...basePlugins, createDefinePlugin('light')];
 const baseConfig = {
   mode: 'development',
   entry: './src/hls',
-  node: false,
   optimization: {
     splitChunks: false
   },


### PR DESCRIPTION
### This PR will...
- Load fragments in chunks via the progress callback from the fragment loader
- Implement progressive CMAF transmuxing:
    - The demuxer splits incoming data into complete MOOF+MDAT pairs
    - Saves any remaining data, which is passed to the remuxer on flush
    - Removes NonProgressiveDemuxer extension
- Converts stream-controllers & base classes to TypeScript
- Resets contiguous-ness of remuxer via function call, as opposed to `contiguous` argument
- Add new logs & improve existing logs

Breaking Changes:
- `STREAM_STATE_TRANSITION` state has been removed

### Why is this Pull Request needed?
So that CMAF streams can be buffered while downloading, allowing Hls.js to reduce the latency to the edge of the live stream.

### Are there any points in the code the reviewer needs to double check?
Sure

### Resolves issues:
JW8-2661
