### PR TITLE
[Do not merge] Implement simple playback rate controller

### DIFF
--- a/src/controller/playback-rate-controller.ts
+++ b/src/controller/playback-rate-controller.ts
@@ -1,0 +1,63 @@
+import TaskLoop from "../task-loop";
+import { BufferHelper } from '../utils/buffer-helper';
+import Event from '../events';
+import EWMA from '../utils/ewma';
+
+const sampleRate: number = 250;
+
+export default class PlaybackRateController extends TaskLoop {
+  protected hls: any;
+  private config: any;
+  private media: any | null = null;
+  private ewma: EWMA;
+  private latencyTarget: number = 3;
+  private refreshLatency = 1;
+
+  constructor(hls) {
+    super(hls,
+      Event.MEDIA_ATTACHED,
+      Event.MEDIA_DETACHING
+    );
+    this.hls = hls;
+    this.config = hls.config;
+    this.ewma = new EWMA(hls.config.abrEwmaFastLive);
+  }
+
+  onMediaAttached (data) {
+    this.media = data.media;
+    this.setInterval(sampleRate);
+  }
+
+  onMediaDetaching () {
+    this.clearInterval();
+    this.media = null
+  }
+
+
+  doTick () {
+    const { config, latencyTarget, media } = this;
+    if (!media) {
+      return;
+    }
+    const pos = media.currentTime;
+    const bufferInfo = BufferHelper.bufferInfo(media, pos, config.maxBufferHole);
+    const bufferLength = bufferInfo.len;
+    const distance = latencyTarget - bufferLength;
+
+    // TODO: Factor amount of forward buffer into refreshLatency
+    // TODO: Make slowdowns less drastic, but still allow it to fall back to the target
+    if (distance < 0 || distance > this.refreshLatency) {
+      media.playbackRate = sigmoid(bufferLength, latencyTarget);
+    } else {
+      media.playbackRate = 1;
+    }
+  }
+}
+
+const L = 2; // Change playback rate by up to 2x
+const k = 0.5;
+const sigmoid = (x, x0) => L / (1 + Math.exp(-k * (x - x0)));
+
+
+// Random TODO: BufferHelper.bufferInfo is used in several classes. Should shift functionality
+// into a managed class ala Shaka's playhead controller

--- a/src/hls.js
+++ b/src/hls.js
@@ -11,6 +11,7 @@ import KeyLoader from './loader/key-loader';
 import { FragmentTracker } from './controller/fragment-tracker';
 import StreamController from './controller/stream-controller';
 import LevelController from './controller/level-controller';
+import PlaybackRateController from './controller/playback-rate-controller';
 
 import { isSupported } from './is-supported';
 import { logger, enableLogs } from './utils/logger';
@@ -111,27 +112,23 @@ export default class Hls extends Observer {
     this.config = config;
     this._autoLevelCapping = -1;
 
-    // core controllers and network loaders
-
+    // Core controllers and network loaders
     /**
      * @member {AbrController} abrController
      */
     const abrController = this.abrController = new config.abrController(this); // eslint-disable-line new-cap
-
     const bufferController = new config.bufferController(this); // eslint-disable-line new-cap
     const capLevelController = new config.capLevelController(this); // eslint-disable-line new-cap
     const fpsController = new config.fpsController(this); // eslint-disable-line new-cap
     const playListLoader = new PlaylistLoader(this);
-    // const fragmentLoader = new FragmentLoader(this);
     const keyLoader = new KeyLoader(this);
+    const playbackRateController = new PlaybackRateController(this);
 
-    // network controllers
-
+    // Network controllers
     /**
      * @member {LevelController} levelController
      */
     const levelController = this.levelController = new LevelController(this);
-
     // FIXME: FragmentTracker must be defined before StreamController because the order of event handling is important
     const fragmentTracker = new FragmentTracker(this);
 
@@ -141,8 +138,7 @@ export default class Hls extends Observer {
     const streamController = this.streamController = new StreamController(this, fragmentTracker);
 
     let networkControllers = [levelController, streamController];
-
-    // optional audio stream controller
+    // Optional audio stream controller
     /**
      * @var {ICoreComponent | Controller}
      */


### PR DESCRIPTION
### This PR will...
- Implement a playback rate controller based on a [logistics curve](https://en.wikipedia.org/wiki/Logistic_function).
    - Changes playback rate based on the distance from the latency target
    - Can change the rate from 0 to 2
- Adds a hardcoded latency target (to be changed)
- Adds a hardcoded forward dead zone (to be changed)
    - Forward deadzone is intended to deal with the buffering delay between the end of the last segment and start of the next segment, caused by manifest refresh


Todo:
- Add latency target config
- Only enable if playing an LHLS stream (Maybe? To be discussed)
- Increase latency if continuously stalling

### Why is this Pull Request needed?

So that an LHLS stream is able to stick to a latency target and stay "low latency"

### Are there any points in the code the reviewer needs to double check?
 See above