### PR TITLE
[JW8-5661] Implement preliminary playlist refresh synchronization

### DIFF
--- a/src/controller/audio-track-controller.js
+++ b/src/controller/audio-track-controller.js
@@ -1,9 +1,8 @@
 import Event from '../events';
-import TaskLoop from '../task-loop';
 import { logger } from '../utils/logger';
 import { ErrorTypes, ErrorDetails } from '../errors';
-import {computeReloadInterval} from "./level-helper";
-import EventHandler from "../event-handler";
+import { computeReloadInterval } from './level-helper';
+import EventHandler from '../event-handler';
 
 /**
  * @class AudioTrackController
@@ -110,19 +109,20 @@ class AudioTrackController extends EventHandler {
    * @param {} data
    */
   onAudioTrackLoaded (data) {
-    const { id, details, previousDetails } = data;
+    const { id, details } = data;
 
     if (id >= this.tracks.length) {
       logger.warn('Invalid audio track id:', id);
       return;
     }
 
-    logger.log(`audioTrack ${id} loaded`);
-
-    this.tracks[id].details = details;
+    logger.log(`audioTrack ${id} loaded [${details.startSN},${details.endSN}]`);
 
     // if current playlist is a live playlist, arm a timer to reload it
     if (details.live) {
+      const curDetails = this.tracks[id].details;
+      details.updated = (!curDetails || details.endSN !== curDetails.endSN || details.url !== curDetails.url);
+      details.availabilityDelay = curDetails && curDetails.availabilityDelay;
       const reloadInterval = computeReloadInterval(details, data.stats, 'audio track');
       logger.log(`live audio track ${details.updated ? 'REFRESHED' : 'MISSED'}, reload in ${Math.round(reloadInterval)} ms`);
       // Stop reloading if the timer was cleared

--- a/src/controller/level-helper.js
+++ b/src/controller/level-helper.js
@@ -207,21 +207,52 @@ export function adjustSliding (oldPlaylist, newPlaylist) {
   }
 }
 
-export function computeReloadInterval (currentPlaylist, newPlaylist, lastRequestTime) {
-  let reloadInterval = 1000 * (newPlaylist.averagetargetduration ? newPlaylist.averagetargetduration : newPlaylist.targetduration);
-  const minReloadInterval = reloadInterval / 2;
-  if (currentPlaylist && newPlaylist.endSN === currentPlaylist.endSN) {
+export function computeReloadInterval (newDetails, { trequest: lastRequestTime = 0 } = {}) {
+  const reloadInterval = 1000 * (newDetails.averagetargetduration ? newDetails.averagetargetduration : newDetails.targetduration);
+  const minReloadInterval = 50; // TODO: set a better minimum based on stats
+  const timeSinceLastModified = newDetails.lastModified ? new Date() - newDetails.lastModified : 0;
+  const timeSinceLastRequested = performance.now() - lastRequestTime;
+
+  let estimatedTimeUntilUpdate = reloadInterval;
+  let availabilityDelay = newDetails.availabilityDelay;
+
+  if (newDetails.updated === false) {
     // follow HLS Spec, If the client reloads a Playlist file and finds that it has not
     // changed then it MUST wait for a period of one-half the target
     // duration before retrying.
-    reloadInterval = minReloadInterval;
+    estimatedTimeUntilUpdate = reloadInterval / 2;
+
+    if (lastRequestTime) {
+      // Reload faster when the time since the last request is closer to the reload interval
+      estimatedTimeUntilUpdate = Math.min(reloadInterval - timeSinceLastRequested, estimatedTimeUntilUpdate);
+    }
+  } else if (timeSinceLastModified > 0 && timeSinceLastModified < reloadInterval) {
+    // Get the closest we've been to timeSinceLastModified on update
+    availabilityDelay = Math.min(availabilityDelay || reloadInterval / 2, timeSinceLastModified);
+    // TODO: Network controllers should maintain this and other stats, rather than passing it from one level details to then next after each response
+    newDetails.availabilityDelay = availabilityDelay;
+    // TODO: Back off from reloading too close to the time the server is expected to update,  rather than using this hardcoded value
+    const minAvailabilityDelay = 1000;
+    estimatedTimeUntilUpdate = Math.max( availabilityDelay / 2, minAvailabilityDelay) + reloadInterval - timeSinceLastModified;
   }
 
-  if (lastRequestTime) {
-    reloadInterval = Math.max(minReloadInterval, reloadInterval - (window.performance.now() - lastRequestTime));
+  // console.log(`[computeReloadInterval] live last requested ${newDetails.updated ? 'REFRESHED' : 'MISSED'}`,
+  //   '\n  average target duration', reloadInterval,
+  //   '\n  estimated time until update =>', estimatedTimeUntilUpdate,
+  //   '\n  time since modified', timeSinceLastModified,
+  //   '\n  time since request', timeSinceLastRequested,
+  //   '\n  availability delay', availabilityDelay);
+
+  return Math.round(Math.max(minReloadInterval, estimatedTimeUntilUpdate));
+}
+
+export function getProgramDateTimeAtEndOfLastEncodedFragment(levelDetails) {
+  if (levelDetails.hasProgramDateTime) {
+    const encodedFragments = levelDetails.fragments.filter((fragment) => !fragment.prefetch);
+    const lastEncodedFrag = encodedFragments[encodedFragments.length - 1];
+    return lastEncodedFrag.programDateTime + lastEncodedFrag.duration * 1000;
   }
-  // in any case, don't reload more than half of target duration
-  return Math.round(reloadInterval);
+  return null;
 }
 
 export function getFragmentWithSN (level, sn) {

--- a/src/controller/level-helper.js
+++ b/src/controller/level-helper.js
@@ -233,7 +233,7 @@ export function computeReloadInterval (newDetails, { trequest: lastRequestTime =
     newDetails.availabilityDelay = availabilityDelay;
     // TODO: Back off from reloading too close to the time the server is expected to update,  rather than using this hardcoded value
     const minAvailabilityDelay = 1000;
-    estimatedTimeUntilUpdate = Math.max( availabilityDelay / 2, minAvailabilityDelay) + reloadInterval - timeSinceLastModified;
+    estimatedTimeUntilUpdate = Math.max(availabilityDelay / 2, minAvailabilityDelay) + reloadInterval - timeSinceLastModified;
   }
 
   // console.log(`[computeReloadInterval] live last requested ${newDetails.updated ? 'REFRESHED' : 'MISSED'}`,
@@ -246,7 +246,7 @@ export function computeReloadInterval (newDetails, { trequest: lastRequestTime =
   return Math.round(Math.max(minReloadInterval, estimatedTimeUntilUpdate));
 }
 
-export function getProgramDateTimeAtEndOfLastEncodedFragment(levelDetails) {
+export function getProgramDateTimeAtEndOfLastEncodedFragment (levelDetails) {
   if (levelDetails.hasProgramDateTime) {
     const encodedFragments = levelDetails.fragments.filter((fragment) => !fragment.prefetch);
     const lastEncodedFrag = encodedFragments[encodedFragments.length - 1];

--- a/src/controller/level-helper.js
+++ b/src/controller/level-helper.js
@@ -221,8 +221,9 @@ export function computeReloadInterval (newDetails, stats = {}) {
   if (newDetails.updated === false) {
     if (useLastModified) {
       // estimate = 'miss round trip';
-      // We should have had a hit so try again in the time it takes to get a response, but no less than 100ms
-      const minRetry = 100;
+      // We should have had a hit so try again in the time it takes to get a response,
+      // but no less than ~1/4 second. After 4 retries, at least 1.1 seconds will have gone by.
+      const minRetry = 283;
       estimatedTimeUntilUpdate = Math.max(Math.min(reloadIntervalAfterMiss, roundTrip), minRetry);
     } else {
       // estimate = 'miss half average - round trip';

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -142,6 +142,9 @@ export class SubtitleStreamController extends BaseStreamController {
     }
 
     if (details.live) {
+      const curDetails = currentTrack.details;
+      details.updated = (!curDetails || details.endSN !== curDetails.endSN || details.url !== curDetails.url);
+      details.availabilityDelay = curDetails && curDetails.availabilityDelay;
       mergeSubtitlePlaylists(currentTrack.details, details, this.lastAVStart);
     }
     currentTrack.details = details;

--- a/src/controller/subtitle-stream-controller.js
+++ b/src/controller/subtitle-stream-controller.js
@@ -142,9 +142,6 @@ export class SubtitleStreamController extends BaseStreamController {
     }
 
     if (details.live) {
-      const curDetails = currentTrack.details;
-      details.updated = (!curDetails || details.endSN !== curDetails.endSN || details.url !== curDetails.url);
-      details.availabilityDelay = curDetails && curDetails.availabilityDelay;
       mergeSubtitlePlaylists(currentTrack.details, details, this.lastAVStart);
     }
     currentTrack.details = details;

--- a/src/controller/subtitle-track-controller.js
+++ b/src/controller/subtitle-track-controller.js
@@ -95,13 +95,12 @@ class SubtitleTrackController extends EventHandler {
       return;
     }
 
-    logger.log(`subtitle track ${id} loaded`);
+    logger.log(`subtitle track ${id} loaded [${details.startSN},${details.endSN}]`);
+
     if (details.live) {
       const curDetails = currentTrack.details;
-      // This should be updated by subtitle-stream-controller but it handles this event before this class
-      if (curDetails !== details) {
-        details.updated = (!curDetails || details.endSN !== curDetails.endSN || details.url !== curDetails.url);
-      }
+      details.updated = (!curDetails || details.endSN !== curDetails.endSN || details.url !== curDetails.url);
+      details.availabilityDelay = curDetails && curDetails.availabilityDelay;
       const reloadInterval = computeReloadInterval(details, data.stats);
       logger.log(`live subtitle track ${details.updated ? 'REFRESHED' : 'MISSED'}, reload in ${Math.round(reloadInterval)} ms`);
       this.timer = setTimeout(() => {

--- a/src/controller/subtitle-track-controller.js
+++ b/src/controller/subtitle-track-controller.js
@@ -97,8 +97,13 @@ class SubtitleTrackController extends EventHandler {
 
     logger.log(`subtitle track ${id} loaded`);
     if (details.live) {
-      const reloadInterval = computeReloadInterval(currentTrack.details, details, data.stats.trequest);
-      logger.log(`Reloading live subtitle playlist in ${reloadInterval}ms`);
+      const curDetails = currentTrack.details;
+      // This should be updated by subtitle-stream-controller but it handles this event before this class
+      if (curDetails !== details) {
+        details.updated = (!curDetails || details.endSN !== curDetails.endSN || details.url !== curDetails.url);
+      }
+      const reloadInterval = computeReloadInterval(details, data.stats);
+      logger.log(`live subtitle track ${details.updated ? 'REFRESHED' : 'MISSED'}, reload in ${Math.round(reloadInterval)} ms`);
       this.timer = setTimeout(() => {
         this._loadCurrentTrack();
       }, reloadInterval);

--- a/src/hls.js
+++ b/src/hls.js
@@ -169,7 +169,6 @@ export default class Hls extends Observer {
     this.audioTrackController = this.createController(config.audioTrackController, null, networkControllers);
     this.createController(config.audioStreamController, fragmentTracker, networkControllers);
 
-
     // subtitleTrackController must be defined before  because the order of event handling is important
     /**
      * @member {SubtitleTrackController} subtitleTrackController
@@ -190,7 +189,7 @@ export default class Hls extends Observer {
     this.coreComponents = coreComponents;
   }
 
-  createController(ControllerClass, fragmentTracker, components) {
+  createController (ControllerClass, fragmentTracker, components) {
     if (ControllerClass) {
       const controllerInstance = fragmentTracker ? new ControllerClass(this, fragmentTracker) : new ControllerClass(this);
       if (components) {

--- a/src/hls.js
+++ b/src/hls.js
@@ -179,7 +179,7 @@ export default class Hls extends Observer {
        * @member {AudioTrackController} audioTrackController
        */
       this.audioTrackController = audioTrackController;
-      coreComponents.push(audioTrackController);
+      networkControllers.push(audioTrackController);
     }
 
     Controller = config.subtitleTrackController;
@@ -278,10 +278,6 @@ export default class Hls extends Observer {
     this.networkControllers.forEach(controller => {
       controller.startLoad(startPosition);
     });
-    const audioTrackController = this.audioTrackController;
-    if (audioTrackController) {
-      audioTrackController.startLoad();
-    }
   }
 
   /**
@@ -292,10 +288,6 @@ export default class Hls extends Observer {
     this.networkControllers.forEach(controller => {
       controller.stopLoad();
     });
-    const audioTrackController = this.audioTrackController;
-    if (audioTrackController) {
-      audioTrackController.stopLoad();
-    }
   }
 
   /**

--- a/src/hls.js
+++ b/src/hls.js
@@ -278,6 +278,10 @@ export default class Hls extends Observer {
     this.networkControllers.forEach(controller => {
       controller.startLoad(startPosition);
     });
+    const audioTrackController = this.audioTrackController;
+    if (audioTrackController) {
+      audioTrackController.startLoad();
+    }
   }
 
   /**
@@ -288,6 +292,10 @@ export default class Hls extends Observer {
     this.networkControllers.forEach(controller => {
       controller.stopLoad();
     });
+    const audioTrackController = this.audioTrackController;
+    if (audioTrackController) {
+      audioTrackController.stopLoad();
+    }
   }
 
   /**

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -356,10 +356,6 @@ class PlaylistLoader extends EventHandler {
     stats.expires = toDate(loader.getResponseHeader('Expires'));
     stats.date = toDate(loader.getResponseHeader('Date'));
 
-    const sinceFirstByte = Math.max(performance.now() - stats.tfirst, 0);
-    const firstByteDate = new Date();
-    firstByteDate.setTime(firstByteDate.getTime() - sinceFirstByte);
-
     levelDetails.tload = stats.tload;
     levelDetails.lastModified = Math.max(stats.mtime, stats.encoded);
 

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -110,6 +110,6 @@ export interface Loader<T extends LoaderContext> {
     config: LoaderConfiguration,
     callbacks: LoaderCallbacks<T>,
   ): void
-
+  getResponseHeader(name:string): string | null
   context: T
 }

--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -58,7 +58,7 @@ class XhrLoader implements Loader<LoaderContext> {
     this.context = context;
     this.config = config;
     this.callbacks = callbacks;
-    this.stats.trequest = window.performance.now();
+    this.stats.trequest = performance.now();
     this.retryDelay = config.retryDelay;
     this.loadInternal();
   }
@@ -121,14 +121,14 @@ class XhrLoader implements Loader<LoaderContext> {
       // clear xhr timeout and rearm it if readyState less than 4
       window.clearTimeout(this.requestTimeout);
       if (stats.tfirst === 0) {
-        stats.tfirst = Math.max(window.performance.now(), stats.trequest);
+        stats.tfirst = Math.max(performance.now(), stats.trequest);
       }
 
       if (readyState === 4) {
         const status = xhr.status;
         // http status between 200 to 299 are all successful
         if (status >= 200 && status < 300) {
-          stats.tload = Math.max(stats.tfirst, window.performance.now());
+          stats.tload = Math.max(performance.now(), stats.tfirst);
           let data;
           let len : number;
           if (context.responseType === 'arraybuffer') {
@@ -145,7 +145,11 @@ class XhrLoader implements Loader<LoaderContext> {
             onProgress(stats, context, data, xhr);
           }
 
-          const response = { url: xhr.responseURL, data: data };
+          const response = {
+            url: xhr.responseURL,
+            data: data
+          };
+
           this.callbacks.onSuccess(response, stats, context, xhr);
         } else {
           // if max nb of retries reached or if http status between 400 and 499 (such error cannot be recovered, retrying is useless), return error
@@ -188,6 +192,15 @@ class XhrLoader implements Loader<LoaderContext> {
     }
     const onProgress = this.callbacks.onProgress as Function;
     onProgress(stats, this.context, data, xhr);
+  }
+
+  getResponseHeader(name: string): string | null {
+      if (this.loader) {
+          try {
+            return this.loader.getResponseHeader(name);
+          } catch (error) {/* Could not get headers */}
+      }
+      return null;
   }
 }
 

--- a/tests/unit/controller/audio-stream-controller.js
+++ b/tests/unit/controller/audio-stream-controller.js
@@ -1,0 +1,68 @@
+import AudioStreamController from '../../../src/controller/audio-stream-controller';
+import Hls from '../../../src/hls';
+
+const sinon = require('sinon');
+
+describe('AudioStreamController', function () {
+  const tracks = [{
+    groupId: '1',
+    id: 0,
+    default: true,
+    name: 'A'
+  }, {
+    groupId: '1',
+    id: 1,
+    default: false,
+    name: 'B'
+  }, {
+    groupId: '1',
+    id: 2,
+    name: 'C'
+  }, {
+    groupId: '2',
+    id: 0,
+    default: true,
+    name: 'A'
+  }, {
+    groupId: '2',
+    id: 1,
+    default: false,
+    name: 'B'
+  }, {
+    groupId: '3',
+    id: 2,
+    name: 'C'
+  }];
+
+  let hls;
+  let audioStreamController;
+
+  beforeEach(function () {
+    hls = new Hls();
+    audioStreamController = new AudioStreamController(hls);
+  });
+
+  afterEach(function () {
+    hls.destroy();
+  });
+
+  describe('onAudioTrackLoaded', function () {
+    it('should update the level details from the event data', function () {
+      const details = {
+        live: false,
+        fragments: [{}],
+        targetduration: 100
+      };
+
+      audioStreamController.levels = tracks;
+      audioStreamController.tick = () => {};
+
+      audioStreamController.onAudioTrackLoaded({
+        id: 0,
+        details
+      });
+
+      expect(audioStreamController.levels[0].details).to.equal(details);
+    });
+  });
+});

--- a/tests/unit/controller/audio-track-controller.js
+++ b/tests/unit/controller/audio-track-controller.js
@@ -93,38 +93,40 @@ describe('AudioTrackController', function () {
   });
 
   describe('onAudioTrackLoaded', function () {
-    it('should set the track details from the event data but not set the interval for a non-live track', function () {
+    it('should not set the track details from the event data and clear the timer for a non-live track', function () {
       const details = {
         live: false,
         targetduration: 100
       };
 
       audioTrackController.tracks = tracks;
+      audioTrackController.canLoad = true;
 
       audioTrackController.onAudioTrackLoaded({
         id: 0,
         details
       });
 
-      expect(audioTrackController.tracks[0].details).to.equal(details);
-      expect(audioTrackController.hasInterval()).to.be.false;
+      expect(audioTrackController.tracks[0].details).to.equal(undefined);
+      expect(audioTrackController.timer).to.equal(null);
     });
 
-    it('should set the track details from the event data and set the interval for a live track', function () {
+    it('should not set the track details from the event data and set the timer for a live track', function () {
       const details = {
         live: true,
         targetduration: 100
       };
 
       audioTrackController.tracks = tracks;
+      audioTrackController.canload = true;
 
       audioTrackController.onAudioTrackLoaded({
         id: 0,
         details
       });
 
-      expect(audioTrackController.tracks[0].details).to.equal(details);
-      expect(audioTrackController.hasInterval()).to.be.true;
+      expect(audioTrackController.tracks[0].details).to.equal(undefined);
+      expect(audioTrackController.timer).to.be.a('number');
     });
   });
 
@@ -300,32 +302,32 @@ describe('AudioTrackController', function () {
 
   describe('onError', function () {
     it('should clear interval (only) on fatal network errors', function () {
-      audioTrackController.setInterval(1000);
+      audioTrackController.timer = 1000;
 
       audioTrackController.onError({
         type: Hls.ErrorTypes.MEDIA_ERROR
       });
 
-      expect(audioTrackController.hasInterval()).to.be.true;
+      expect(audioTrackController.timer).to.equal(1000);
       audioTrackController.onError({
         type: Hls.ErrorTypes.MEDIA_ERROR,
         fatal: true
       });
 
-      expect(audioTrackController.hasInterval()).to.be.true;
+      expect(audioTrackController.timer).to.equal(1000);
       audioTrackController.onError({
         type: Hls.ErrorTypes.NETWORK_ERROR,
         fatal: false
       });
 
-      expect(audioTrackController.hasInterval()).to.be.true;
+      expect(audioTrackController.timer).to.equal(1000);
       audioTrackController.onError({
         type: Hls.ErrorTypes.NETWORK_ERROR,
         fatal: true
       });
 
       // fatal network error clears interval
-      expect(audioTrackController.hasInterval()).to.be.false;
+      expect(audioTrackController.timer).to.equal(null);
     });
 
     it('should blacklist current track on fatal network error, and find a backup track (fallback mechanism)', function () {

--- a/tests/unit/controller/level-helper.js
+++ b/tests/unit/controller/level-helper.js
@@ -1,7 +1,6 @@
 import * as LevelHelper from '../../../src/controller/level-helper';
 import Level from '../../../src/loader/level';
 import Fragment from '../../../src/loader/fragment';
-import sinon from 'sinon';
 
 const generatePlaylist = (sequenceNumbers) => {
   const playlist = new Level('');
@@ -182,21 +181,21 @@ describe('LevelHelper Tests', function () {
       const newPlaylist = generatePlaylist([3, 4]);
       newPlaylist.averagetargetduration = 5;
       newPlaylist.updated = true;
-
-      const clock = sandbox.useFakeTimers();
-      clock.tick(2000);
-      const actual = LevelHelper.computeReloadInterval(newPlaylist, 1000);
+      const actual = LevelHelper.computeReloadInterval(newPlaylist, {
+        trequest: 0,
+        tload: 1000
+      });
       expect(actual).to.equal(4000);
     });
 
     it('returns a minimum of half the target duration', function () {
       const newPlaylist = generatePlaylist([3, 4]);
       newPlaylist.averagetargetduration = 5;
-      newPlaylist.updated = true;
-
-      const clock = sandbox.useFakeTimers();
-      clock.tick(9000);
-      const actual = LevelHelper.computeReloadInterval(newPlaylist, 1000);
+      newPlaylist.updated = false;
+      const actual = LevelHelper.computeReloadInterval(newPlaylist, {
+        trequest: 0,
+        tload: 1000
+      });
       expect(actual).to.equal(2500);
     });
   });

--- a/tests/unit/controller/level-helper.js
+++ b/tests/unit/controller/level-helper.js
@@ -142,61 +142,61 @@ describe('LevelHelper Tests', function () {
 
   describe('computeReloadInterval', function () {
     it('returns the averagetargetduration of the new level if available', function () {
-      const oldPlaylist = generatePlaylist([1, 2]);
       const newPlaylist = generatePlaylist([3, 4]);
       newPlaylist.averagetargetduration = 5;
-      const actual = LevelHelper.computeReloadInterval(oldPlaylist, newPlaylist, null);
+      newPlaylist.updated = true;
+      const actual = LevelHelper.computeReloadInterval(newPlaylist, null);
       expect(actual).to.equal(5000);
     });
 
     it('returns the targetduration of the new level if averagetargetduration is falsy', function () {
-      const oldPlaylist = generatePlaylist([1, 2]);
       const newPlaylist = generatePlaylist([3, 4]);
       newPlaylist.averagetargetduration = null;
       newPlaylist.targetduration = 4;
-      let actual = LevelHelper.computeReloadInterval(oldPlaylist, newPlaylist, null);
+      newPlaylist.updated = true;
+      let actual = LevelHelper.computeReloadInterval(newPlaylist, null);
       expect(actual).to.equal(4000);
 
       newPlaylist.averagetargetduration = null;
-      actual = LevelHelper.computeReloadInterval(oldPlaylist, newPlaylist, null);
+      actual = LevelHelper.computeReloadInterval(newPlaylist, null);
       expect(actual).to.equal(4000);
     });
 
     it('halves the reload interval if the playlist contains the same segments', function () {
-      const oldPlaylist = generatePlaylist([1, 2]);
       const newPlaylist = generatePlaylist([1, 2]);
+      newPlaylist.updated = false;
       newPlaylist.averagetargetduration = 5;
-      const actual = LevelHelper.computeReloadInterval(oldPlaylist, newPlaylist, null);
+      const actual = LevelHelper.computeReloadInterval(newPlaylist, null);
       expect(actual).to.equal(2500);
     });
 
     it('rounds the reload interval', function () {
-      const oldPlaylist = generatePlaylist([1, 2]);
       const newPlaylist = generatePlaylist([3, 4]);
       newPlaylist.averagetargetduration = 5.9999;
-      const actual = LevelHelper.computeReloadInterval(oldPlaylist, newPlaylist, null);
+      newPlaylist.updated = true;
+      const actual = LevelHelper.computeReloadInterval(newPlaylist, null);
       expect(actual).to.equal(6000);
     });
 
     it('subtracts the request time of the last level load from the reload interval', function () {
-      const oldPlaylist = generatePlaylist([1, 2]);
       const newPlaylist = generatePlaylist([3, 4]);
       newPlaylist.averagetargetduration = 5;
+      newPlaylist.updated = true;
 
       const clock = sandbox.useFakeTimers();
       clock.tick(2000);
-      const actual = LevelHelper.computeReloadInterval(oldPlaylist, newPlaylist, 1000);
+      const actual = LevelHelper.computeReloadInterval(newPlaylist, 1000);
       expect(actual).to.equal(4000);
     });
 
     it('returns a minimum of half the target duration', function () {
-      const oldPlaylist = generatePlaylist([1, 2]);
       const newPlaylist = generatePlaylist([3, 4]);
       newPlaylist.averagetargetduration = 5;
+      newPlaylist.updated = true;
 
       const clock = sandbox.useFakeTimers();
       clock.tick(9000);
-      const actual = LevelHelper.computeReloadInterval(oldPlaylist, newPlaylist, 1000);
+      const actual = LevelHelper.computeReloadInterval(newPlaylist, 1000);
       expect(actual).to.equal(2500);
     });
   });


### PR DESCRIPTION
### This PR will...
- When a live playlist is updated, schedule it's reload in-sync with with the program-date-time at the end of the last encoded segment, or the Last-Modified header
- When a live playlist is loaded but not updated, schedule it's reload as we did before, but with a minimum interval of 50ms
- Add an `updated` property to level/track details which indicates if the level/track was updated after if was loaded
- Schedule the reloading of audio tracks using `computeReloadInterval`, the same logic used for levels and subtitle tracks (it was being reloaded on a fixed interval by extending `TaskLoop`)
- Stop refreshing levels and tracks when `stopLoad` is called (audio track was never stopped)
- Question why we trigger `UPDATED` events after loading playlists when nothing new was found in the playlist


### Why is this Pull Request needed?
To update live playlists loser to the time when they are updated on the server. This allows playback closer to the live edge.

### Are there any points in the code the reviewer needs to double check?
See TODOs, other comments and logging.

Additional requirements to consider, not added in these changes:
- For LHLS, when the first prefetch segment is completely loaded, use this as a trigger to re-request the playlist (the fact that all the bytes are available and loaded is a perfect indication that a playlist update should be available). This will help improve the synchronization on top of the changes to `computeReloadInterval` added here.
- Some `fuzzing` of reload scheduling (or target latency) could be needed at scale to prevent all clients from hitting the server/CDN at the same time.
- When program-date-time or Last-Modified header dates are not in sync with the client's clock, the logic here should still work thanks to enforced ranges, but could impact the results. Additional testing and solutions for determining the offset between the client and the stream's clock could help, but ideally require 'Date' header or a clock end-point.
- The audio/subtitle stream/track controllers share track details and other responsibilities, but don't operate on loaded events in a consistent order. Ownership is mixed (`AudioTrackController` is not a network controller, but it loaded audio track playlists?). All of this make them difficult to use and prone to conflicts. 

### Resolves issues:
JW8-5661

### Checklist

- [x] changes have been done against **LHLS** branch, and PR does not conflict
- [ ] new (**updated**) unit / functional tests have been added (whenever applicable)
- [ ] **N/A** ~API or design changes are documented in API.md~
