### PR TITLE
Address starting and stopping of levels and audio tracks

### DIFF
--- a/src/controller/audio-track-controller.js
+++ b/src/controller/audio-track-controller.js
@@ -1,5 +1,6 @@
 import Event from '../events';
-import TaskLoop from '../task-loop';
+import EventHandler from '../event-handler';
+import { computeReloadInterval } from './level-helper';
 import { logger } from '../utils/logger';
 import { ErrorTypes, ErrorDetails } from '../errors';
 
@@ -24,7 +25,7 @@ import { ErrorTypes, ErrorDetails } from '../errors';
  * @fires ERROR
  *
  */
-class AudioTrackController extends TaskLoop {
+class AudioTrackController extends EventHandler {
   constructor (hls) {
     super(hls,
       Event.MANIFEST_LOADING,
@@ -70,6 +71,13 @@ class AudioTrackController extends TaskLoop {
      * @member {string}
      */
     this.audioGroupId = null;
+
+    this.canload = false;
+    this.timer = null;
+  }
+
+  onHandlerDestroying () {
+    this.clearTimer();
   }
 
   /**
@@ -101,28 +109,44 @@ class AudioTrackController extends TaskLoop {
    * @param {} data
    */
   onAudioTrackLoaded (data) {
-    if (data.id >= this.tracks.length) {
-      logger.warn('Invalid audio track id:', data.id);
+    const { id, details } = data;
+    if (id >= this.tracks.length) {
+      logger.warn('Invalid audio track id:', id);
       return;
     }
 
-    logger.log(`audioTrack ${data.id} loaded`);
-
-    this.tracks[data.id].details = data.details;
-
-    // check if current playlist is a live playlist
-    // and if we have already our reload interval setup
-    if (data.details.live && !this.hasInterval()) {
-      // if live playlist we will have to reload it periodically
-      // set reload period to playlist target duration
-      const updatePeriodMs = data.details.targetduration * 1000;
-      this.setInterval(updatePeriodMs);
-    }
-
-    if (!data.details.live && this.hasInterval()) {
+    logger.log(`audioTrack ${id} loaded`);
+    if (details.live) {
+      const curDetails = this.tracks[id].details;
+      const reloadInterval = computeReloadInterval(curDetails, details, data.stats.trequest);
+      logger.log(`Reloading live audio track in ${reloadInterval}ms`);
+      // Stop reloading if the timer was cleared
+      if (this.canload) {
+        this.timer = setTimeout(() => this._updateTrack(this._trackId), reloadInterval);
+      }
+    } else {
       // playlist is not live and timer is scheduled: cancel it
-      this.clearInterval();
+      this.clearTimer();
     }
+  }
+
+  clearTimer () {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  startLoad () {
+    this.canload = true;
+    if (this.timer === null) {
+      this._updateTrack(this._trackId);
+    }
+  }
+
+  stopLoad () {
+    this.canload = false;
+    this.clearTimer();
   }
 
   /**
@@ -180,7 +204,7 @@ class AudioTrackController extends TaskLoop {
 
     // If fatal network error, cancel update task
     if (data.fatal) {
-      this.clearInterval();
+      this.clearTimer();
     }
 
     // If not an audio-track loading error don't handle further
@@ -237,19 +261,12 @@ class AudioTrackController extends TaskLoop {
     logger.log(`Now switching to audio-track index ${newId}`);
 
     // stopping live reloading timer if any
-    this.clearInterval();
+    this.clearTimer();
     this._trackId = newId;
 
     const { url, type, id } = audioTrack;
     this.hls.trigger(Event.AUDIO_TRACK_SWITCHING, { id, type, url });
     this._loadTrackDetailsIfNeeded(audioTrack);
-  }
-
-  /**
-   * @override
-   */
-  doTick () {
-    this._updateTrack(this._trackId);
   }
 
   /**
@@ -352,7 +369,7 @@ class AudioTrackController extends TaskLoop {
     }
 
     // stopping live reloading timer if any
-    this.clearInterval();
+    this.clearTimer();
     this._trackId = newId;
     logger.log(`trying to update audio-track ${newId}`);
     const audioTrack = this.tracks[newId];

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -65,6 +65,7 @@ export default class LevelController extends EventHandler {
 
   stopLoad () {
     this.canload = false;
+    this.clearTimer();
   }
 
   onManifestLoaded (data) {

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1286,8 +1286,16 @@ class StreamController extends BaseStreamController {
     */
     const media = this.mediaBuffer ? this.mediaBuffer : this.media;
     if (media) {
+      // Handle DOMException caused by SourceBuffer beeing removed
+      let buffered;
+      try {
+        buffered = media.buffered;
+      } catch (e) {
+        // DOMException: Failed to read the 'buffered' property from 'SourceBuffer': This SourceBuffer has been removed from the parent media source.
+        buffered = [];
+      }
       // filter fragments potentially evicted from buffer. this is to avoid memleak on live streams
-      this.fragmentTracker.detectEvictedFragments(Fragment.ElementaryStreamTypes.VIDEO, media.buffered);
+      this.fragmentTracker.detectEvictedFragments(Fragment.ElementaryStreamTypes.VIDEO, buffered);
     }
     // move to IDLE once flush complete. this should trigger new fragment loading
     this.state = State.IDLE;

--- a/src/hls.js
+++ b/src/hls.js
@@ -143,20 +143,6 @@ export default class Hls extends Observer {
 
     let networkControllers = [levelController, streamController];
 
-    // optional audio stream controller
-    /**
-     * @var {ICoreComponent | Controller}
-     */
-    let Controller = config.audioStreamController;
-    if (Controller) {
-      networkControllers.push(new Controller(this, fragmentTracker));
-    }
-
-    /**
-     * @member {INetworkController[]} networkControllers
-     */
-    this.networkControllers = networkControllers;
-
     /**
      * @var {ICoreComponent[]}
      */
@@ -171,6 +157,10 @@ export default class Hls extends Observer {
       fragmentTracker
     ];
 
+    let Controller;
+
+    // audioTrackController must be defined before audioStreamController because the order of event handling is important
+
     // optional audio track and subtitle controller
     Controller = config.audioTrackController;
     if (Controller) {
@@ -180,9 +170,19 @@ export default class Hls extends Observer {
        * @member {AudioTrackController} audioTrackController
        */
       this.audioTrackController = audioTrackController;
-      coreComponents.push(audioTrackController);
+      networkControllers.push(audioTrackController);
     }
 
+    // optional audio stream controller
+    /**
+     * @var {ICoreComponent | Controller}
+     */
+    Controller = config.audioStreamController;
+    if (Controller) {
+      networkControllers.push(new Controller(this, fragmentTracker));
+    }
+
+    // subtitleTrackController must be defined before  because the order of event handling is important
     Controller = config.subtitleTrackController;
     if (Controller) {
       const subtitleTrackController = new Controller(this);
@@ -192,6 +192,12 @@ export default class Hls extends Observer {
        */
       this.subtitleTrackController = subtitleTrackController;
       networkControllers.push(subtitleTrackController);
+    }
+
+    // optional subtitle controllers
+    Controller = config.subtitleStreamController;
+    if (Controller) {
+      networkControllers.push(new Controller(this, fragmentTracker));
     }
 
     Controller = config.emeController;
@@ -205,15 +211,15 @@ export default class Hls extends Observer {
       coreComponents.push(emeController);
     }
 
-    // optional subtitle controllers
-    Controller = config.subtitleStreamController;
-    if (Controller) {
-      networkControllers.push(new Controller(this, fragmentTracker));
-    }
     Controller = config.timelineController;
     if (Controller) {
       coreComponents.push(new Controller(this));
     }
+
+    /**
+     * @member {INetworkController[]} networkControllers
+     */
+    this.networkControllers = networkControllers;
 
     /**
      * @member {ICoreComponent[]}


### PR DESCRIPTION
### This PR will...
- Load audio tracks with the same timing we use to load level and subtitle playlists.
- Handle an exception that gets thrown after stopping and starting a stream (WIP)

### Additional considerations
The goal here is to get playback stop and restart in JW Player to work with live streams. Currently it does not if playback is stopped for longer than the playlist duration (live window), especially when the stream is adaptive and uses audio tracks. The issue probably lies more in how the source bufferers are being treated, as well as handling of currentTime and the buffered ranged. When we restart loading the player is not in a state where it can just begin loading and buffering again, with currentTime updated to a new buffered range.

### Why is this Pull Request needed?
Audio track loading runs on a fixed interval rather than using the same time estimates used to load other playlists. This can cause loading to get out of sync, and can also result in audio tracks being requested after playback has been stopped (like when jwplayer preloads the media)

## Are there any Pull Requests open in other repos which need to be merged with this?
The following PR addresses stopping and starting of live streams by simply using a new hls.js player instance to restart the stream. This is best in the short-term.
https://github.com/jwplayer/jwplayer-commercial/pull/6476

The changes made in this PR are also included in the LHLS work I've been doing with @johnBartos and unless there is an urgent need for these improvements, we may choose to hold them until v1.0.

### [WIP] ~Resolves issues~:
JW8-5261

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
