### PR TITLE
[JW8-8969] Place LoaderStats on the Fragment class, and remove from Controller prototypes

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -16,7 +16,6 @@ import BaseStreamController, { State } from './base-stream-controller';
 import FragmentLoader from '../loader/fragment-loader';
 import { findFragmentByPTS } from './fragment-finders';
 import Fragment from '../loader/fragment';
-import { LoaderStats } from '../types/loader';
 
 const { performance } = window;
 
@@ -28,7 +27,6 @@ class AudioStreamController extends BaseStreamController {
   private onvseeking: Function | null = null;
   private onvseeked: Function | null = null;
   private onvended: Function | null = null;
-  private stats!: LoaderStats;
   private videoBuffer: any | null = null;
   private initPTS: any = [];
   private waitingFragment: Fragment | null = null;
@@ -641,19 +639,6 @@ class AudioStreamController extends BaseStreamController {
       text.id = id;
       hls.trigger(Event.FRAG_PARSING_USERDATA, text);
     }
-  }
-
-  private _handleTransmuxerFlush () {
-    this._endParsing();
-  }
-
-  private _endParsing () {
-    if (this.state !== State.PARSING) {
-      return;
-    }
-    this.stats.tparsed = window.performance.now();
-    this.state = State.PARSED;
-    this._checkAppendedParsed();
   }
 
   private _bufferInitSegment (tracks) {

--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -280,7 +280,7 @@ export default class BaseStreamController extends TaskLoop {
     }
     // Assign fragCurrent. References to fragments in the level details change between playlist refreshes.
     // TODO: Preserve frag references between live playlist refreshes
-    frag = fragCurrent;
+    frag = fragCurrent!;
     return { frag, level: currentLevel };
   }
 

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -18,7 +18,6 @@ import { findFragmentByPDT, findFragmentByPTS } from './fragment-finders';
 import GapController from './gap-controller';
 import BaseStreamController, { State } from './base-stream-controller';
 import FragmentLoader, { FragLoadSuccessResult } from '../loader/fragment-loader';
-import { LoaderStats } from '../types/loader';
 
 const TICK_INTERVAL = 100; // how often to tick in ms
 
@@ -42,7 +41,6 @@ export default class StreamController extends BaseStreamController {
   private fragLastKbps: number = 0;
   private stalled: boolean = false;
   private audioCodecSwitch: boolean = false;
-  private stats!: LoaderStats;
   private pendingBuffering: boolean = false;
   private appended: boolean = false;
   private videoBuffer: any | null = null;
@@ -1263,23 +1261,6 @@ export default class StreamController extends BaseStreamController {
       text.id = id;
       hls.trigger(Event.FRAG_PARSING_USERDATA, text);
     }
-  }
-
-  private _handleTransmuxerFlush ({ sn, level }) {
-    this._endParsing();
-  }
-
-  private _endParsing () {
-    if (this.state !== State.PARSING) {
-      return;
-    }
-    if (this.stats) {
-      this.stats.tparsed = window.performance.now();
-    } else {
-      this.warn(`Stats object was unset after fragment finished parsing. tparsed will not be recorded for ${this.fragCurrent}`);
-    }
-    this.state = State.PARSED;
-    this._checkAppendedParsed();
   }
 
   private _bufferInitSegment (currentLevel, tracks) {

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -64,10 +64,10 @@ export default class FragmentLoader {
       }
       const callbacks: LoaderCallbacks<FragmentLoaderContext> = {
           onSuccess: (response, stats, context, networkDetails) => {
+              this.setStats(frag, stats);
               this._resetLoader(frag);
               resolve({
                   payload: response.data as ArrayBuffer,
-                  stats,
                   networkDetails
               });
           },
@@ -83,7 +83,8 @@ export default class FragmentLoader {
               }));
           },
           onAbort: (stats, context, networkDetails) => {
-              this._resetLoader(frag);
+            this.setStats(frag, stats);
+            this._resetLoader(frag);
               reject(new LoadError({
                   type: ErrorTypes.NETWORK_ERROR,
                   details: ErrorDetails.INTERNAL_ABORTED,
@@ -103,10 +104,10 @@ export default class FragmentLoader {
               }));
           },
           onProgress: (stats, context, data, networkDetails) => {
+            this.setStats(frag, stats);
             if (onProgress) {
               onProgress({
                 payload: data as ArrayBuffer,
-                stats,
                 networkDetails
               });
             }
@@ -120,6 +121,12 @@ export default class FragmentLoader {
     frag.loader = null;
     this.loader = null;
   }
+
+  private setStats (frag: Fragment, stats: LoaderStats) {
+    if (!frag.stats) {
+      frag.stats = stats;
+    }
+  }
 }
 
 export class LoadError extends Error {
@@ -132,7 +139,6 @@ export class LoadError extends Error {
 
 export interface FragLoadSuccessResult {
   payload: ArrayBuffer
-  stats: LoaderStats
   networkDetails: XMLHttpRequest | null
 }
 

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -112,7 +112,7 @@ export default class FragmentLoader {
       // Assign frag stats to the loader's stats reference
       frag.stats = loader.stats;
       // Loaders are used once per fragment and should be reset at this point
-      console.assert(frag.stats.trequest !== 0, 'Frag stats should be unset before loading');
+      console.assert(!frag.stats.trequest, 'Frag stats should be unset before loading');
       loader.load(loaderContext, loaderConfig, callbacks);
     });
   }

--- a/src/loader/fragment-stats.ts
+++ b/src/loader/fragment-stats.ts
@@ -1,0 +1,13 @@
+import { LoaderStats } from '../types/loader';
+
+export default class FragmentStats implements LoaderStats {
+  aborted: boolean = false;
+  loaded: number = 0;
+  retry: number = 0;
+  tbuffered: number = 0;
+  tfirst: number = 0;
+  tload: number = 0;
+  total: number = 0;
+  tparsed: number = 0;
+  trequest: number = 0;
+}

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -3,6 +3,7 @@ import { buildAbsoluteURL } from 'url-toolkit';
 import { logger } from '../utils/logger';
 import LevelKey from './level-key';
 import { LoaderStats } from '../types/loader';
+import FragmentStats from './fragment-stats';
 
 export enum ElementaryStreamTypes {
   AUDIO = 'audio',
@@ -73,8 +74,8 @@ export default class Fragment {
   // Set by `updateFragPTSDTS` in level-helper
   public deltaPTS?: number;
   public maxStartPTS?: number;
-  // Timing information
-  public stats!: LoaderStats;
+  // Load/parse timing information
+  public stats: LoaderStats = new FragmentStats();
 
   // setByteRange converts a EXT-X-BYTERANGE attribute into a two element array
   setByteRange (value: string, previousFrag?: Fragment) {

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -2,6 +2,7 @@
 import { buildAbsoluteURL } from 'url-toolkit';
 import { logger } from '../utils/logger';
 import LevelKey from './level-key';
+import { LoaderStats } from '../types/loader';
 
 export enum ElementaryStreamTypes {
   AUDIO = 'audio',
@@ -72,6 +73,8 @@ export default class Fragment {
   // Set by `updateFragPTSDTS` in level-helper
   public deltaPTS?: number;
   public maxStartPTS?: number;
+  // Timing information
+  public stats!: LoaderStats;
 
   // setByteRange converts a EXT-X-BYTERANGE attribute into a two element array
   setByteRange (value: string, previousFrag?: Fragment) {

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -2,8 +2,7 @@
 import { buildAbsoluteURL } from 'url-toolkit';
 import { logger } from '../utils/logger';
 import LevelKey from './level-key';
-import { LoaderStats } from '../types/loader';
-import FragmentStats from './fragment-stats';
+import LoadStats from './load-stats';
 
 export enum ElementaryStreamTypes {
   AUDIO = 'audio',
@@ -75,7 +74,7 @@ export default class Fragment {
   public deltaPTS?: number;
   public maxStartPTS?: number;
   // Load/parse timing information
-  public stats: LoaderStats = new FragmentStats();
+  public stats: LoadStats = new LoadStats();
 
   // setByteRange converts a EXT-X-BYTERANGE attribute into a two element array
   setByteRange (value: string, previousFrag?: Fragment) {

--- a/src/loader/load-stats.ts
+++ b/src/loader/load-stats.ts
@@ -1,6 +1,6 @@
 import { LoaderStats } from '../types/loader';
 
-export default class FragmentStats implements LoaderStats {
+export default class LoadStats implements LoaderStats {
   aborted: boolean = false;
   loaded: number = 0;
   retry: number = 0;

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -112,4 +112,5 @@ export interface Loader<T extends LoaderContext> {
   ): void
   getResponseHeader(name:string): string | null
   context: T
+  stats: LoaderStats
 }

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -53,7 +53,7 @@ export interface LoaderStats {
   total: number,
   // number of retries attempted
   retry: number,
-  // the request was cancelled or timedzout
+  // the request was cancelled or timed out
   aborted: boolean
 }
 

--- a/src/utils/fetch-loader.ts
+++ b/src/utils/fetch-loader.ts
@@ -1,4 +1,5 @@
 import { LoaderCallbacks, LoaderContext, Loader, LoaderStats, LoaderConfiguration } from '../types/loader';
+import LoadStats from '../loader/load-stats';
 
 const { fetch, AbortController, ReadableStream, Request, Headers, performance } = window as any;
 
@@ -26,17 +27,7 @@ class FetchLoader implements Loader<LoaderContext> {
   constructor (config /* HlsConfig */) {
     this.fetchSetup = config.fetchSetup || getRequest;
     this.controller = new AbortController();
-    this.stats = {
-      tfirst: 0,
-      trequest: 0,
-      tload: 0,
-      loaded: 0,
-      tparsed: 0,
-      tbuffered: 0,
-      total: 0,
-      retry: 0,
-      aborted: false
-    };
+    this.stats = new LoadStats();
   }
 
   destroy (): void {

--- a/src/utils/xhr-loader.ts
+++ b/src/utils/xhr-loader.ts
@@ -1,5 +1,6 @@
 import { logger } from '../utils/logger';
 import { LoaderCallbacks, LoaderContext, LoaderStats, Loader, LoaderConfiguration } from '../types/loader';
+import LoadStats from '../loader/load-stats';
 
 class XhrLoader implements Loader<LoaderContext> {
   private xhrSetup: Function | null;
@@ -16,17 +17,7 @@ class XhrLoader implements Loader<LoaderContext> {
   constructor (config /* HlsConfig */) {
     this.xhrSetup = config ? config.xhrSetup : null;
     this.loader = null;
-    this.stats = {
-      tfirst: 0,
-      trequest: 0,
-      tload: 0,
-      loaded: 0,
-      tparsed: 0,
-      tbuffered: 0,
-      total: 0,
-      retry: 0,
-      aborted: false
-    };
+    this.stats = new LoadStats();
     this.retryDelay = 0;
   }
 

--- a/tests/unit/loader/fragment-loader.js
+++ b/tests/unit/loader/fragment-loader.js
@@ -4,10 +4,12 @@ import { ErrorDetails, ErrorTypes } from '../../../src/errors';
 import sinon from 'sinon';
 
 class MockXhr {
+  constructor () {
+    this.stats = {};
+  }
   load (context, config, callbacks) {
     this.callbacks = callbacks;
   }
-
   abort () {}
 }
 

--- a/tests/unit/loader/fragment-loader.js
+++ b/tests/unit/loader/fragment-loader.js
@@ -40,9 +40,9 @@ describe('FragmentLoader tests', function () {
         .then(data => {
           expect(data).to.deep.equal({
             payload: response.data,
-            stats,
             networkDetails
           });
+          expect(frag.stats).to.exist;
           expect(fragmentLoader.loader).to.not.exist;
           expect(frag.loader).to.not.exist;
           resolve();


### PR DESCRIPTION
### This PR will...
- Create `LoadStats` class, which implements `LoaderStats`
- Add `stats` to the Fragment class
- Assign `stats` to the fragment in the fragment-loader
- Remove `stats` from audio-stream-controller and level-controller
- Pull `stats` from the fragment instance wherever `this.stats` was used
- Move more shared controller code to the base-stream-controller

### Why is this Pull Request needed?
#208 shifts the responsibility of detecting when a fragment has been buffered from the stream-controllers to the buffer-controller. Therefore, the fragment stats need to be accessible outside of the controllers themselves. In my opinion it makes the most sense to keep the stats on the fragment object itself.

### Are there any points in the code the reviewer needs to double check?
Is there a better way to assign stats to the fragment object?

### Resolves issues:
[JW8-8969]

