### PR TITLE
[JW8-9032] Reset muxers before probing to ensure that they are always reset

### DIFF
--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -114,6 +114,19 @@ class Transmuxer {
     this.timeOffset = timeOffset;
     this.accurateTimeOffset = accurateTimeOffset;
 
+    // Reset muxers before probing to ensure that their state is clean, even if flushing occurs before a successful probe
+    if (discontinuity || trackSwitch) {
+      this.resetInitSegment(uintInitSegment, audioCodec, videoCodec, duration);
+    }
+
+    if (discontinuity) {
+      this.resetInitialTimestamp(defaultInitPTS);
+    }
+
+    if (!contiguous) {
+      this.resetNextTimestamp();
+    }
+
     const needsProbing = this.needsProbing(uintData, discontinuity, trackSwitch);
     if (needsProbing && (uintData.length + cache.dataLength < minProbeByteLength)) {
       logger.log(`[transmuxer.ts]: Received ${uintData.length} bytes, but at least ${minProbeByteLength} are required to probe for demuxer types\n` +
@@ -139,18 +152,6 @@ class Transmuxer {
         remuxResult: {},
         transmuxIdentifier
       };
-    }
-
-    if (discontinuity || trackSwitch) {
-      this.resetInitSegment(uintInitSegment, audioCodec, videoCodec, duration);
-    }
-
-    if (discontinuity) {
-      this.resetInitialTimestamp(defaultInitPTS);
-    }
-
-    if (!contiguous) {
-      this.resetNextTimestamp();
     }
 
    let result;

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -142,7 +142,6 @@ class TSDemuxer extends NonProgressiveDemuxer {
     this.audioCodec = audioCodec;
     this.videoCodec = videoCodec;
     this._duration = duration;
-    super.resetInitSegment(audioCodec, videoCodec, duration);
   }
 
   /**


### PR DESCRIPTION
### Why is this Pull Request needed?
If a flush occurs before probing succeeds, the existing demuxers will not have their state reset. As a result the next fragment will transmux in the context of the previous. This causes various playback errors, such as large numbers of dropped frames.

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
JW8-9032

