### PR TITLE
[JW8-8993] Refactor minProbeByteLength to only be enforced on transmuxer flush 

### DIFF
--- a/src/controller/audio-stream-controller.ts
+++ b/src/controller/audio-stream-controller.ts
@@ -442,7 +442,7 @@ class AudioStreamController extends BaseStreamController {
     // time Offset is accurate if level PTS is known, or if playlist is not sliding (not live)
     let accurateTimeOffset = false; // details.PTSKnown || !details.live;
     const transmuxIdentifier = { level: frag.level, sn: frag.sn };
-    transmuxer.push(payload, initSegmentData, audioCodec, '', frag, details.totalduration, accurateTimeOffset, initPTS, transmuxIdentifier);
+    transmuxer.push(payload, initSegmentData, audioCodec, '', frag, details.totalduration, accurateTimeOffset, transmuxIdentifier, initPTS);
   }
 
   onBufferReset () {

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -853,7 +853,6 @@ export default class StreamController extends BaseStreamController {
       frag,
       details.totalduration,
       accurateTimeOffset,
-      null,
       transmuxIdentifier
     );
   }

--- a/src/demux/mp4demuxer.ts
+++ b/src/demux/mp4demuxer.ts
@@ -7,7 +7,7 @@ import { findBox, segmentValidRange, appendUint8Array } from '../utils/mp4-tools
 import { dummyTrack } from './dummy-demuxed-track';
 
 class MP4Demuxer implements Demuxer {
-  static readonly minProbeByteLength = 16384; // 16kb;
+  static readonly minProbeByteLength = 1024;
   private remainderData: Uint8Array | null = null;
 
   resetTimeStamp () {

--- a/src/demux/transmuxer-worker.ts
+++ b/src/demux/transmuxer-worker.ts
@@ -30,7 +30,6 @@ export default function TransmuxerWorker (self) {
 
   self.addEventListener('message', (ev) => {
     const data = ev.data;
-    // console.log('transmuxer cmd:' + data.cmd);
     switch (data.cmd) {
       case 'init': {
         const config = JSON.parse(data.config);
@@ -39,22 +38,12 @@ export default function TransmuxerWorker (self) {
         forwardMessage('init', null);
         break;
       }
+      case 'configure': {
+        self.transmuxer.configure(data.config, data.state);
+        break;
+      }
       case 'demux': {
-        const transmuxResult: TransmuxerResult = self.transmuxer.push(data.data,
-          data.decryptdata,
-          data.initSegment,
-          data.audioCodec,
-          data.videoCodec,
-          data.timeOffset,
-          data.discontinuity,
-          data.trackSwitch,
-          data.contiguous,
-          data.duration,
-          data.accurateTimeOffset,
-          data.defaultInitPTS,
-          data.transmuxIdentifier
-        );
-
+        const transmuxResult: TransmuxerResult = self.transmuxer.push(data.data, data.decryptdata, data.transmuxIdentifier);
         if (!transmuxResult) {
           return;
         }

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -131,7 +131,6 @@ export default class Transmuxer {
     return result;
   }
 
-  // TODO: Probe for demuxer on flush
   flush (transmuxIdentifier: TransmuxIdentifier) : TransmuxerResult | Promise<TransmuxerResult>  {
     const { demuxer, remuxer, cache, currentTransmuxState, decryptionPromise, observer } = this;
     if (decryptionPromise) {

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -46,7 +46,7 @@ muxConfig.forEach(({ demux }) => {
   minProbeByteLength = Math.max(minProbeByteLength, demux.minProbeByteLength);
 });
 
-class Transmuxer {
+export default class Transmuxer {
   private observer: any;
   private typeSupported: any;
   private config: any;
@@ -56,9 +56,8 @@ class Transmuxer {
   private decrypter: any;
   private probe!: Function;
   private decryptionPromise: Promise<TransmuxerResult> | null = null;
-
-  private timeOffset: number = 0;
-  private accurateTimeOffset: boolean = false;
+  private transmuxConfig!: TransmuxConfig;
+  private currentTransmuxState!: TransmuxState;
 
   private cache: ChunkCache = new ChunkCache();
 
@@ -69,131 +68,107 @@ class Transmuxer {
     this.vendor = vendor;
   }
 
+  configure (transmuxConfig: TransmuxConfig, state: TransmuxState) {
+    this.transmuxConfig = transmuxConfig;
+    this.currentTransmuxState = state;
+  }
+
   push (data: ArrayBuffer,
     decryptdata: any | null,
-    initSegment: any,
-    audioCodec: string,
-    videoCodec: string,
-    timeOffset: number,
-    discontinuity: boolean,
-    trackSwitch: boolean,
-    contiguous: boolean,
-    duration: number,
-    accurateTimeOffset: boolean,
-    defaultInitPTS: number | null,
     transmuxIdentifier: TransmuxIdentifier
   ): TransmuxerResult | Promise<TransmuxerResult> {
     let uintData = new Uint8Array(data);
-    const uintInitSegment = new Uint8Array(initSegment);
-    const cache = this.cache;
     const encryptionType = getEncryptionType(uintData, decryptdata);
 
     // TODO: Handle progressive AES-128 decryption
     if (encryptionType === 'AES-128') {
       this.decryptionPromise = this.decryptAes128(data, decryptdata)
         .then(decryptedData => {
-          const result = this.push(decryptedData,
-            null,
-            initSegment,
-            audioCodec,
-            videoCodec,
-            timeOffset,
-            discontinuity,
-            trackSwitch,
-            contiguous,
-            duration,
-            accurateTimeOffset,
-            defaultInitPTS,
-            transmuxIdentifier);
+          const result = this.push(decryptedData, null, transmuxIdentifier);
           this.decryptionPromise = null;
           return result;
         });
       return this.decryptionPromise;
     }
 
-    this.timeOffset = timeOffset;
-    this.accurateTimeOffset = accurateTimeOffset;
+    const { cache, currentTransmuxState: state, transmuxConfig: config } = this;
+    const { contiguous, discontinuity, trackSwitch, accurateTimeOffset, timeOffset } = state;
+    const { audioCodec, videoCodec, defaultInitPts, duration, initSegmentData } = config;
 
     // Reset muxers before probing to ensure that their state is clean, even if flushing occurs before a successful probe
     if (discontinuity || trackSwitch) {
-      this.resetInitSegment(uintInitSegment, audioCodec, videoCodec, duration);
+      this.resetInitSegment(initSegmentData, audioCodec, videoCodec, duration);
     }
 
     if (discontinuity) {
-      this.resetInitialTimestamp(defaultInitPTS);
+      this.resetInitialTimestamp(defaultInitPts);
     }
 
     if (!contiguous) {
       this.resetNextTimestamp();
     }
 
-    const needsProbing = this.needsProbing(uintData, discontinuity, trackSwitch);
-    if (needsProbing && (uintData.length + cache.dataLength < minProbeByteLength)) {
-      logger.log(`[transmuxer.ts]: Received ${uintData.length} bytes, but at least ${minProbeByteLength} are required to probe for demuxer types\n` +
-        'This data will be cached until the minimum amount is met.');
-      cache.push(uintData);
-      return {
-        remuxResult: {},
-        transmuxIdentifier
-      };
-    } else if (cache.dataLength) {
-      logger.log(`[transmuxer.ts]: Cache now has enough data to probe.`);
-      uintData = appendUint8Array(cache.flush(), uintData);
-    }
-
     let { demuxer, remuxer } = this;
-    if (needsProbing) {
-      ({ demuxer, remuxer } = this.configureTransmuxer(uintData, uintInitSegment, audioCodec, videoCodec, duration));
+    if (this.needsProbing(uintData, discontinuity, trackSwitch)) {
+      uintData = appendUint8Array(cache.flush(), uintData);
+      ({ demuxer, remuxer } = this.configureTransmuxer(uintData, initSegmentData, audioCodec, videoCodec, duration));
     }
 
     if (!demuxer || !remuxer) {
-      this.observer.trigger(Event.ERROR, { type: ErrorTypes.MEDIA_ERROR, details: ErrorDetails.FRAG_PARSING_ERROR, fatal: true, reason: 'no demux matching with content found' });
-      return {
-        remuxResult: {},
-        transmuxIdentifier
-      };
+      cache.push(uintData);
+        return {
+          remuxResult: {},
+          transmuxIdentifier
+        };
     }
 
-   let result;
-   if (encryptionType === 'SAMPLE-AES') {
-      result = this.transmuxSampleAes(uintData, decryptdata, timeOffset, accurateTimeOffset, transmuxIdentifier);
-    } else {
-      result = this.transmux(uintData, timeOffset, accurateTimeOffset, transmuxIdentifier);
-    }
+    const result = this.transmux(uintData, decryptdata, encryptionType, timeOffset, accurateTimeOffset, transmuxIdentifier);
+
+    state.contiguous = true;
+    state.discontinuity = false;
+    state.trackSwitch = false;
+
     return result;
   }
 
   // TODO: Probe for demuxer on flush
   flush (transmuxIdentifier: TransmuxIdentifier) : TransmuxerResult | Promise<TransmuxerResult>  {
-    if (this.decryptionPromise) {
-      return this.decryptionPromise.then(() => {
+    const { demuxer, remuxer, cache, currentTransmuxState, decryptionPromise, observer } = this;
+    if (decryptionPromise) {
+      return decryptionPromise.then(() => {
         return this.flush(transmuxIdentifier);
       });
     }
 
-    this.cache.reset();
-    if (!this.demuxer) {
+    const bytesSeen = cache.dataLength;
+    cache.reset();
+    if (!demuxer || !remuxer) {
+      // If probing failed, and each demuxer saw enough bytes to be able to probe, then Hls.js has been given content its not able to handle
+      if (bytesSeen >= minProbeByteLength) {
+        observer.trigger(Event.ERROR, { type: ErrorTypes.MEDIA_ERROR, details: ErrorDetails.FRAG_PARSING_ERROR, fatal: true, reason: 'no demux matching with content found' });
+      }
       return {
         remuxResult: {},
         transmuxIdentifier
       }
     }
-    const { audioTrack, avcTrack, id3Track, textTrack } = this.demuxer!.flush(this.timeOffset);
+
+    const { accurateTimeOffset, timeOffset } = currentTransmuxState;
+    const { audioTrack, avcTrack, id3Track, textTrack } = demuxer.flush(timeOffset);
     logger.log(`[transmuxer.ts]: Flushed fragment ${transmuxIdentifier.sn} of level ${transmuxIdentifier.level}`);
-    // TODO: ensure that remuxers use last DTS as the timeOffset when passed null
     return {
-        remuxResult: this.remuxer!.remux(audioTrack, avcTrack, id3Track, textTrack, this.timeOffset, this.accurateTimeOffset),
+        remuxResult: remuxer.remux(audioTrack, avcTrack, id3Track, textTrack, timeOffset, accurateTimeOffset),
         transmuxIdentifier
     }
   }
 
-  resetInitialTimestamp (defaultInitPTS) {
+  resetInitialTimestamp (defaultInitPts: number | undefined) {
     const { demuxer, remuxer } = this;
     if (!demuxer || !remuxer) {
       return;
     }
-    demuxer.resetTimeStamp(defaultInitPTS);
-    remuxer.resetTimeStamp(defaultInitPTS);
+    demuxer.resetTimeStamp(defaultInitPts);
+    remuxer.resetTimeStamp(defaultInitPts);
   }
 
   resetNextTimestamp () {
@@ -204,13 +179,13 @@ class Transmuxer {
     remuxer.resetNextTimestamp();
   }
 
-  resetInitSegment (initSegment: Uint8Array, audioCodec: string, videoCodec: string, duration: number) {
+  resetInitSegment (initSegmentData: Uint8Array, audioCodec: string, videoCodec: string, duration: number) {
     const { demuxer, remuxer } = this;
     if (!demuxer || !remuxer) {
       return;
     }
     demuxer.resetInitSegment(audioCodec, videoCodec, duration);
-    remuxer.resetInitSegment(initSegment, audioCodec, videoCodec);
+    remuxer.resetInitSegment(initSegmentData, audioCodec, videoCodec);
   }
 
   destroy (): void {
@@ -224,11 +199,21 @@ class Transmuxer {
     }
   }
 
-  private transmux (data: Uint8Array, timeOffset: number, accurateTimeOffset: boolean, transmuxIdentifier: TransmuxIdentifier): TransmuxerResult {
+  private transmux (data: Uint8Array, decryptData: Uint8Array, encryptionType: string | null, timeOffset: number, accurateTimeOffset: boolean, transmuxIdentifier: TransmuxIdentifier): TransmuxerResult | Promise<TransmuxerResult> {
+    let result: TransmuxerResult | Promise<TransmuxerResult>;
+    if (encryptionType === 'SAMPLE-AES') {
+      result = this.transmuxSampleAes(data, decryptData, timeOffset, accurateTimeOffset, transmuxIdentifier);
+    } else {
+      result = this.transmuxUnencrypted(data, timeOffset, accurateTimeOffset, transmuxIdentifier);
+    }
+    return result;
+  }
+
+  private transmuxUnencrypted (data: Uint8Array, timeOffset: number, accurateTimeOffset: boolean, transmuxIdentifier: TransmuxIdentifier) {
     const { audioTrack, avcTrack, id3Track, textTrack } = this.demuxer!.demux(data, timeOffset,false);
     return {
-        remuxResult: this.remuxer!.remux(audioTrack, avcTrack, id3Track, textTrack, timeOffset, accurateTimeOffset),
-        transmuxIdentifier
+      remuxResult: this.remuxer!.remux(audioTrack, avcTrack, id3Track, textTrack, timeOffset, accurateTimeOffset),
+      transmuxIdentifier
     }
   }
 
@@ -296,4 +281,34 @@ function getEncryptionType (data: Uint8Array, decryptData: any): string | null {
   return encryptionType;
 }
 
-export default Transmuxer;
+export class TransmuxConfig {
+  public audioCodec: string;
+  public videoCodec: string;
+  public initSegmentData: Uint8Array;
+  public duration: number;
+  public defaultInitPts?: number;
+
+  constructor (audioCodec: string, videoCodec: string, initSegmentData: Uint8Array, duration: number, defaultInitPts?: number) {
+    this.audioCodec = audioCodec;
+    this.videoCodec = videoCodec;
+    this.initSegmentData = initSegmentData;
+    this.duration = duration;
+    this.defaultInitPts = defaultInitPts;
+  }
+}
+
+export class TransmuxState {
+  public discontinuity: boolean;
+  public contiguous: boolean;
+  public accurateTimeOffset: boolean;
+  public trackSwitch: boolean;
+  public timeOffset: number;
+
+  constructor(discontinuity: boolean, contiguous: boolean, accurateTimeOffset: boolean, trackSwitch: boolean, timeOffset: number){
+    this.discontinuity = discontinuity;
+    this.contiguous = contiguous;
+    this.accurateTimeOffset = accurateTimeOffset;
+    this.trackSwitch = trackSwitch;
+    this.timeOffset = timeOffset;
+  }
+}

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -35,7 +35,7 @@ const RemuxerTrackIdConfig = {
 };
 
 class TSDemuxer implements Demuxer {
-  static readonly minProbeByteLength = 1024;
+  static readonly minProbeByteLength = 188;
 
   private observer: any;
   private config: any;


### PR DESCRIPTION
### This PR will...
- Attempt to probe on each transmux call
- Cache data if probing fails
- Throws the "no demuxer found" error on flush if probing did not succeed, and enough bytes were seen to be able to probe
- Refactors the transmuxer to have a separate method for configuration, as opposed to passing everything via the `push` call

### Why is this Pull Request needed?
So that very small segments (< 16kb in our test stream) are able to be probed. Previously, the transmuxer would enforce a minimum byte length before attempting to probe. This PR changes it so that we opportunistically probe (on every push), and only throw a fatal error if no demuxer/remuxer has been chosen by the time we flush. The byte length enforcement on flush is to ensure that we avoid false positives when calling flush when aborting fragment loads.

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
JW8-8993