### PR TITLE
[JW8-9270] Cancel progressive fragment load when seeking outside the buffered range

### DIFF
--- a/src/controller/base-stream-controller.ts
+++ b/src/controller/base-stream-controller.ts
@@ -84,7 +84,7 @@ export default class BaseStreamController extends TaskLoop {
   }
 
   protected onMediaSeeking () {
-    const { config, media, mediaBuffer, state } = this;
+    const { config, fragCurrent, media, mediaBuffer, state } = this;
     const currentTime = media ? media.currentTime : null;
     const bufferInfo = BufferHelper.bufferInfo(mediaBuffer || media, currentTime, this.config.maxBufferHole);
 
@@ -92,40 +92,32 @@ export default class BaseStreamController extends TaskLoop {
       this.log(`media seeking to ${currentTime.toFixed(3)}, state: ${state}`);
     }
 
-    // TODO: Handle frag abort while progressively parsing (state is PARSING after the first progress event)
-    if (state === State.FRAG_LOADING) {
-      let fragCurrent = this.fragCurrent;
-      // check if we are seeking to a unbuffered area AND if frag loading is in progress
-      if (!bufferInfo.len && fragCurrent) {
-        const tolerance = config.maxFragLookUpTolerance;
-        const fragStartOffset = fragCurrent.start - tolerance;
-        const fragEndOffset = fragCurrent.start + fragCurrent.duration + tolerance;
-        // check if we seek position will be out of currently loaded frag range : if out cancel frag load, if in, don't do anything
-        if (currentTime < fragStartOffset || currentTime > fragEndOffset) {
-          if (fragCurrent.loader) {
-            this.log('seeking outside of buffer while fragment load in progress, cancel fragment load');
-            fragCurrent.loader.abort();
-          }
-          this.fragCurrent = null;
-          this.fragPrevious = null;
-          // switch to IDLE state to load new fragment
-          this.state = State.IDLE;
-        } else {
-          this.log('seeking outside of buffer but within currently loaded fragment range');
-        }
-      } else {
-        this.log(`didn't cancel, len: ${bufferInfo.len}, fragCurrent: ${fragCurrent}`);
-      }
-    } else if (state === State.ENDED) {
+    if (state === State.ENDED) {
       // if seeking to unbuffered area, clean up fragPrevious
-      if (bufferInfo.len === 0) {
+      if (!bufferInfo.len) {
         this.fragPrevious = null;
         this.fragCurrent = null;
       }
-
       // switch to IDLE state to check for potential new fragment
       this.state = State.IDLE;
+    } else if (fragCurrent && !bufferInfo.len) {
+      // check if we are seeking to a unbuffered area AND if frag loading is in progress
+      const tolerance = config.maxFragLookUpTolerance;
+      const fragStartOffset = fragCurrent.start - tolerance;
+      const fragEndOffset = fragCurrent.start + fragCurrent.duration + tolerance;
+      // check if we seek position will be out of currently loaded frag range : if out cancel frag load, if in, don't do anything
+      if (currentTime < fragStartOffset || currentTime > fragEndOffset) {
+        if (fragCurrent.loader) {
+          this.log('seeking outside of buffer while fragment load in progress, cancel fragment load');
+          fragCurrent.loader.abort();
+        }
+        this.fragCurrent = null;
+        this.fragPrevious = null;
+        // switch to IDLE state to load new fragment
+        this.state = State.IDLE;
+      }
     }
+
     if (media) {
       this.lastCurrentTime = currentTime;
     }

--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -252,10 +252,11 @@ export default class BufferController extends EventHandler {
 
   onFragParsed ({ frag }) {
     let buffersAppendedTo: Array<SourceBufferName> = [];
-    if (frag.hasElementaryStream(ElementaryStreamTypes.AUDIO)) {
+
+    if (frag.elementaryStreams[ElementaryStreamTypes.AUDIO]) {
       buffersAppendedTo.push('audio');
     }
-    if (frag.hasElementaryStream(ElementaryStreamTypes.VIDEO)) {
+    if (frag.elementaryStreams[ElementaryStreamTypes.VIDEO]) {
       buffersAppendedTo.push('video');
     }
     console.assert(buffersAppendedTo.length, 'Fragments must have at least one ElementaryStreamType set', frag);

--- a/src/controller/fragment-tracker.js
+++ b/src/controller/fragment-tracker.js
@@ -1,5 +1,6 @@
 import EventHandler from '../event-handler';
 import Event from '../events';
+import { ElementaryStreamTypes } from '../loader/fragment';
 
 export const FragmentState = {
   NOT_LOADED: 'NOT_LOADED',
@@ -105,7 +106,7 @@ export class FragmentTracker extends EventHandler {
       fragmentEntity.buffered = true;
 
       Object.keys(this.timeRanges).forEach(elementaryStream => {
-        if (fragment.hasElementaryStream(elementaryStream)) {
+        if (fragment.elementaryStreams[elementaryStream]) {
           let timeRange = this.timeRanges[elementaryStream];
           // Check for malformed fragments
           // Gaps need to be calculated for each elementaryStream

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -15,15 +15,22 @@ export enum FragmentTypes {
   SUBTITLE = 'subtitle'
 }
 
+interface ElementaryStreamInfo {
+  startPTS: number
+  endPTS: number
+  startDTS: number
+  endDTS: number
+}
+
 export default class Fragment {
   private _url: string | null = null;
   private _byteRange: number[] | null = null;
   private _decryptdata: LevelKey | null = null;
 
   // Holds the types of data this fragment supports
-  private _elementaryStreams: Record<ElementaryStreamTypes, boolean> = {
-    [ElementaryStreamTypes.AUDIO]: false,
-    [ElementaryStreamTypes.VIDEO]: false
+  public elementaryStreams: Record<ElementaryStreamTypes, ElementaryStreamInfo | null> = {
+    [ElementaryStreamTypes.AUDIO]: null,
+    [ElementaryStreamTypes.VIDEO]: null
   };
 
   public rawProgramDateTime: string | null = null;
@@ -169,21 +176,6 @@ export default class Fragment {
   }
 
   /**
-   * @param {ElementaryStreamTypes} type
-   */
-  addElementaryStream (type: ElementaryStreamTypes) {
-    this._elementaryStreams[type] = true;
-  }
-
-  /**
-   * @param {ElementaryStreamTypes} type
-   */
-  hasElementaryStream (type: ElementaryStreamTypes) {
-    return this._elementaryStreams[type];
-  }
-
-
-  /**
    * Utility method for parseLevelPlaylist to create an initialization vector for a given segment
    * @param {number} segmentNumber - segment number to generate IV with
    * @returns {Uint8Array}
@@ -214,5 +206,24 @@ export default class Fragment {
     }
 
     return decryptdata;
+  }
+
+  setElementaryStreamInfo (type: ElementaryStreamTypes, startPTS: number, endPTS: number, startDTS: number, endDTS: number) {
+    const { elementaryStreams } = this;
+    const info = elementaryStreams[type];
+    if (!info) {
+      elementaryStreams[type] = {
+        startPTS,
+        endPTS,
+        startDTS,
+        endDTS
+      };
+      return;
+    }
+
+    info.startPTS = Math.min(info.startPTS, startPTS);
+    info.endPTS = Math.max(info.endPTS, endPTS);
+    info.startDTS = Math.min(info.startDTS, startDTS);
+    info.endDTS = Math.max(info.endDTS, endDTS);
   }
 }

--- a/tests/unit/controller/buffer-controller-operations.ts
+++ b/tests/unit/controller/buffer-controller-operations.ts
@@ -180,8 +180,8 @@ describe('BufferController SourceBuffer operation queueing', function () {
     it('should trigger FRAG_BUFFERED when all audio/video data has been buffered', function () {
       const flushLiveBackBufferSpy = sandbox.spy(bufferController, 'flushLiveBackBuffer');
       const frag = new Fragment();
-      frag.addElementaryStream(ElementaryStreamTypes.AUDIO);
-      frag.addElementaryStream(ElementaryStreamTypes.VIDEO);
+      frag.setElementaryStreamInfo(ElementaryStreamTypes.AUDIO, 0, 0, 0, 0);
+      frag.setElementaryStreamInfo(ElementaryStreamTypes.VIDEO, 0, 0, 0, 0);
 
       bufferController.onFragParsed({ frag });
       expect(queueAppendBlockerSpy).to.have.been.calledTwice;

--- a/tests/unit/controller/fragment-tracker.js
+++ b/tests/unit/controller/fragment-tracker.js
@@ -14,10 +14,10 @@ function createMockBuffer (buffered) {
 }
 
 function createMockFragment (data, types) {
-  data._elementaryStreams = new Set(types);
-  data.hasElementaryStream = (type) => {
-    return data._elementaryStreams.has(type) === true;
-  };
+  data.elementaryStreams = {};
+  types.forEach(t => {
+    data.elementaryStreams[t] = {};
+  });
   return data;
 }
 


### PR DESCRIPTION
### This PR will...
- Cancel fragment load if the loader exists and the seek point is outside of the buffer, regardless of controller state
- Refactor fragment timing to only update on transmux complete instead of every progress event

### Why is this Pull Request needed?

So that when seeking, the currently loading fragment does not block the next fragment from loading. This problem causes seeking to be slow.

### Are there any points in the code the reviewer needs to double check?
No

Breaking Changes
- Fragment.ts object
    - hasElementaryStream API has been removed
    - setElementaryStream API has been removed
    - _elementaryStreams property has been removed


### Resolves issues:
JW8-9270
