### PR TITLE
Update fragment.level indexes when removing levels

### DIFF
--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -459,7 +459,7 @@ export default class LevelController extends EventHandler {
   }
 
   removeLevel (levelIndex, urlId) {
-    this._levels = this.levels.filter((level, index) => {
+    const levels = this.levels.filter((level, index) => {
       if (index !== levelIndex) {
         return true;
       }
@@ -470,8 +470,18 @@ export default class LevelController extends EventHandler {
         return true;
       }
       return false;
+    }).map((level, index) => {
+      const { details } = level;
+      if (details && details.fragments) {
+        details.fragments.forEach((fragment) => {
+          fragment.level = index;
+        });
+      }
+      return level;
     });
 
-    this.hls.trigger(Event.LEVELS_UPDATED, { levels: this._levels });
+    this._levels = levels;
+
+    this.hls.trigger(Event.LEVELS_UPDATED, { levels });
   }
 }


### PR DESCRIPTION
### This PR will...
Update fragment.level indexes when removing levels.

### Why is this Pull Request needed?
We remove levels that error on load using `hlsjs.removeLevel(index)`. This works fine with live streams, but results in errors with VOD streams. The issue stems from fragment objects having a `level` property that is the index of its level in `hlsjs.levels`. The index is used to look up level details in the stream-controller. While that property is updated with every _live_ manifest refresh, it is never updated for _VOD_.

Currently, when we call `hlsjs.removeLevel()`, fragment loading of an active level with a higher index will fail because the hlsjs cannot look up level.details in the stream-controller. A JavaScript error is logged to console while the stream no longer buffers and behaves as if stalled.

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer/pull/3426
https://github.com/jwplayer/jwplayer-commercial/pull/6731

### Resolves issues:
JW8-9327 (TODO: Sub-bug)
