### PR TITLE
[JW8-9515 ] Polyfill Object.assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@babel/helper-module-imports": "7.0.0",
     "@babel/plugin-proposal-class-properties": "^7.3.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
+    "@babel/plugin-transform-object-assign": "^7.2.0",
     "@babel/preset-env": "7.2.0",
     "@babel/preset-typescript": "^7.1.0",
     "@babel/register": "^7.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,7 +80,8 @@ const baseConfig = {
                   }
                 }
               }
-            }
+            },
+            ['@babel/plugin-transform-object-assign']
           ]
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -459,6 +459,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-transform-object-assign@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.2.0.tgz#6fdeea42be17040f119e38e23ea0f49f31968bde"
+  integrity sha512-nmE55cZBPFgUktbF2OuoZgPRadfxosLOpSgzEPYotKSls9J4pEPcembi8r78RU37Rph6UApCpNmsQA4QMWK9Ng==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-transform-object-super@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz#b35d4c10f56bab5d650047dad0f1d8e8814b6598"


### PR DESCRIPTION
### Why is this Pull Request needed?
So that we can use Object.assign in browsers which do not support it. The cost of this polyfill is minimal:

```
function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
```

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
JW8-9515 

