### PR TITLE
Only remux text/id3 when the initPTS is known JW8-9741

### DIFF
--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -108,12 +108,14 @@ export default class MP4Remuxer implements Remuxer {
       }
     }
 
-    if (id3Track.samples.length) {
-      id3 = this.remuxID3(id3Track);
-    }
+    if (this.ISGenerated) {
+      if (id3Track.samples.length) {
+        id3 = this.remuxID3(id3Track);
+      }
 
-    if (textTrack.samples.length) {
-      text = this.remuxText(textTrack);
+      if (textTrack.samples.length) {
+        text = this.remuxText(textTrack);
+      }
     }
 
     return {


### PR DESCRIPTION
### Why is this Pull Request needed?
So that if we receive text/id3 before the track's PTS is known, we avoid producing `NaN` timestamps caused by doing math with an undefined `initPTS`

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
JW8-9741 

