### PR TITLE
Fix bad backtracking behavior JW8-9119

### DIFF
--- a/src/controller/level-helper.ts
+++ b/src/controller/level-helper.ts
@@ -125,6 +125,8 @@ export function mergeDetails (oldDetails: LevelDetails, newDetails: LevelDetails
     if (Number.isFinite(oldFrag.startPTS)) {
       newFrag.start = newFrag.startPTS = oldFrag.startPTS;
       newFrag.endPTS = oldFrag.endPTS;
+      newFrag.startDTS = oldFrag.startDTS;
+      newFrag.endDTS = oldFrag.endDTS;
       newFrag.duration = oldFrag.duration;
       newFrag.backtracked = oldFrag.backtracked;
       newFrag.dropped = oldFrag.dropped;

--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -383,18 +383,8 @@ export default class StreamController extends BaseStreamController {
       if (fragPrevious && frag.sn === fragPrevious.sn) {
         if (sameLevel && !frag.backtracked) {
           if (frag.sn < levelDetails.endSN) {
-            let deltaPTS = fragPrevious.deltaPTS;
-            // if there is a significant delta between audio and video, larger than max allowed hole,
-            // and if previous remuxed fragment did not start with a keyframe. (fragPrevious.dropped)
-            // let's try to load previous fragment again to get last keyframe
-            // then we will reload again current fragment (that way we should be able to fill the buffer hole ...)
-            if (deltaPTS && deltaPTS > config.maxBufferHole && fragPrevious.dropped && curSNIdx && !frag.backtracked) {
-              frag = prevFrag;
-              this.warn('SN just loaded, with large PTS gap between audio and video, maybe frag is not starting with a keyframe ? load previous one to try to overcome this');
-            } else {
-              frag = nextFrag;
-              this.log(`SN just loaded, load next one: ${frag.sn}`);
-            }
+            frag = nextFrag;
+            this.log(`SN just loaded, load next one: ${frag.sn}`);
           } else {
             frag = null;
           }
@@ -406,7 +396,6 @@ export default class StreamController extends BaseStreamController {
           } else {
             // If a fragment has dropped frames and it's in a same level/sequence, load the previous fragment to try and find the keyframe
             // Reset the dropped count now since it won't be reset until we parse the fragment again, which prevents infinite backtracking on the same segment
-            this.warn('Loaded fragment with dropped frames, backtracking 1 segment to find a keyframe');
             frag.dropped = 0;
             if (prevFrag) {
               frag = prevFrag;
@@ -1295,7 +1284,7 @@ function _hasDroppedFrames (frag, dropped, startSN) {
     frag.dropped = dropped;
     if (!frag.backtracked) {
       if (frag.sn === startSN) {
-        logger.warn(`[stream-controller]:  Fragment ${frag.sn} of level ${frag.level} is missing ${frag.dropped} video frame(s); this is the start fragment and will be appended with a gap`);
+        logger.warn(`[stream-controller]: Fragment ${frag.sn} of level ${frag.level} is missing ${frag.dropped} video frame(s); this is the start fragment and will be appended with a gap`);
         return false;
       } else {
         logger.warn(`[stream-controller]: Fragment ${frag.sn} of level ${frag.level} is missing ${frag.dropped} video frame(s); backtracking to find a keyframe`);

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -62,9 +62,9 @@ export default class MP4Remuxer implements Remuxer {
     const isVideoContiguous = Number.isFinite(this.nextAvcDts!);
     if (!isVideoContiguous && this.config.forceKeyFrameOnDiscontinuity) {
       const length = videoTrack.samples.length;
-      dropSamplesUntilKeyframe(videoTrack);
-      if (videoTrack.dropped) {
-        logger.warn(`[mp4-remuxer]: Dropped ${videoTrack.dropped} out of ${length} video samples due to a missing keyframe`);
+      const dropped = dropSamplesUntilKeyframe(videoTrack);
+      if (dropped) {
+        logger.warn(`[mp4-remuxer]: Dropped ${dropped} out of ${length} video samples due to a missing keyframe`);
       }
     }
 
@@ -749,7 +749,7 @@ function PTSNormalize (value: number, reference: number | null): number {
   return value;
 }
 
-function dropSamplesUntilKeyframe (track: DemuxedTrack) : void {
+function dropSamplesUntilKeyframe (track: DemuxedTrack) : number {
   const samples = track.samples;
   let dropIndex = 0;
   for (let i = 0; i < samples.length; i++) {
@@ -759,10 +759,11 @@ function dropSamplesUntilKeyframe (track: DemuxedTrack) : void {
     }
     dropIndex++;
   }
-  track.dropped = dropIndex;
+  track.dropped += dropIndex;
   if (dropIndex) {
     track.samples = samples.slice(dropIndex);
   }
+  return dropIndex;
 }
 
 


### PR DESCRIPTION
### This PR will...
- Propagate `startDTS` and `endDTS` when merging live fragments
- Remove extraneous backtracking case
- Keep a running count of dropped samples per track, instead of the number of dropped samples for the current chunk

### Why is this Pull Request needed?
There is some undefined behavior caused by backtracking when it should not be performed. This PR ensures that we're only backtracking when necessary.

See the linked ticket for test streams.

### Are there any points in the code the reviewer needs to double check?

### Resolves issues:

JW8-9119