### PR TITLE
Fix and improve alternate audio handling JW8-9824

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -456,7 +456,8 @@ export default class BufferController extends EventHandler {
             buffer: sb,
             codec: codec,
             container: track.container,
-            levelCodec: track.levelCodec
+            levelCodec: track.levelCodec,
+            id: track.id
           };
         } catch (err) {
           logger.error(`error while trying to add sourceBuffer:${err.message}`);

--- a/src/controller/fragment-finders.js
+++ b/src/controller/fragment-finders.js
@@ -96,3 +96,15 @@ export function pdtWithinToleranceTest (pdtBufferEnd, maxFragLookUpTolerance, ca
   let candidateLookupTolerance = Math.min(maxFragLookUpTolerance, candidate.duration + (candidate.deltaPTS ? candidate.deltaPTS : 0)) * 1000;
   return candidate.endProgramDateTime - candidateLookupTolerance > pdtBufferEnd;
 }
+
+export function findFragWithCC (fragments, CC) {
+  return BinarySearch.search(fragments, (candidate) => {
+    if (candidate.cc < CC) {
+      return 1;
+    } else if (candidate.cc > CC) {
+      return -1;
+    } else {
+      return 0;
+    }
+  });
+}

--- a/src/demux/aacdemuxer.ts
+++ b/src/demux/aacdemuxer.ts
@@ -29,6 +29,9 @@ class AACDemuxer implements Demuxer {
   resetTimeStamp () {
   }
 
+  resetContiguity (): void {
+  }
+
   // Source for probe info - https://wiki.multimedia.cx/index.php?title=ADTS
   static probe (data) {
     if (!data) {

--- a/src/demux/mp3demuxer.ts
+++ b/src/demux/mp3demuxer.ts
@@ -22,6 +22,9 @@ class MP3Demuxer implements Demuxer {
   resetTimeStamp () {
   }
 
+  resetContiguity (): void {
+  }
+
   static probe (data) {
     // check if data contains ID3 timestamp and MPEG sync word
     let offset, length;

--- a/src/demux/mp4demuxer.ts
+++ b/src/demux/mp4demuxer.ts
@@ -16,6 +16,9 @@ class MP4Demuxer implements Demuxer {
   resetInitSegment () {
   }
 
+  resetContiguity (): void {
+  }
+
   static probe (data) {
     // ensure we find a moof box in the first 16 kB
     return findBox({ data: data, start: 0, end: Math.min(data.length, 16384) }, ['moof']).length > 0;

--- a/src/demux/transmuxer-interface.ts
+++ b/src/demux/transmuxer-interface.ts
@@ -154,6 +154,7 @@ export default class TransmuxerInterface {
 
   flush (transmuxIdentifier: TransmuxIdentifier) {
     const { transmuxer, worker } = this;
+    this.currentTransmuxSession = null;
     if (worker) {
       worker.postMessage({
         cmd: 'flush',

--- a/src/demux/tsdemuxer.ts
+++ b/src/demux/tsdemuxer.ts
@@ -141,6 +141,21 @@ class TSDemuxer implements Demuxer {
   resetTimeStamp () {
   }
 
+  resetContiguity (): void {
+    const { _audioTrack, _avcTrack, _id3Track } = this;
+    if (_audioTrack) {
+      _audioTrack.pesData = null;
+    }
+    if (_avcTrack) {
+      _avcTrack.pesData = null;
+    }
+    if (_id3Track) {
+      _id3Track.pesData = null;
+    }
+    this.aacOverFlow = null;
+    this.aacLastPTS = null;
+  }
+
   demux (data: Uint8Array, contiguous, timeOffset, isSampleAes = false): DemuxerResult {
     if (!isSampleAes) {
       this.sampleAes = null;
@@ -495,7 +510,7 @@ class TSDemuxer implements Demuxer {
         break;
 
       default:
-        logger.log('unknown stream type:' + data[offset]);
+        // logger.log('unknown stream type:' + data[offset]);
         break;
       }
       // move to the next table entry

--- a/src/hls.js
+++ b/src/hls.js
@@ -558,7 +558,7 @@ export default class Hls extends Observer {
    * @type {Seconds}
    */
   get liveSyncPosition () {
-    return this.streamController.liveSyncPosition;
+    return this.streamController._liveSyncPosition;
   }
 
   /**

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -83,6 +83,8 @@ export default class Fragment {
   // Load/parse timing information
   public stats: LoadStats = new LoadStats();
   public urlId: number = 0;
+  // TODO: Create InitSegment class extended from Fragment
+  public data?: ArrayBuffer;
 
   // setByteRange converts a EXT-X-BYTERANGE attribute into a two element array
   setByteRange (value: string, previousFrag?: Fragment) {

--- a/src/types/demuxer.ts
+++ b/src/types/demuxer.ts
@@ -5,6 +5,7 @@ export interface Demuxer {
   destroy() : void
   resetInitSegment(audioCodec: string, videoCodec: string, duration: number);
   resetTimeStamp(defaultInitPTS?: number | null): void;
+  resetContiguity(): void;
 }
 
 export interface DemuxerResult {

--- a/src/utils/discontinuities.js
+++ b/src/utils/discontinuities.js
@@ -15,18 +15,6 @@ export function findFirstFragWithCC (fragments, cc) {
   return firstFrag;
 }
 
-export function findFragWithCC (fragments, CC) {
-  return BinarySearch.search(fragments, (candidate) => {
-    if (candidate.cc < CC) {
-      return 1;
-    } else if (candidate.cc > CC) {
-      return -1;
-    } else {
-      return 0;
-    }
-  });
-}
-
 export function shouldAlignOnDiscontinuities (lastFrag, lastLevel, details) {
   let shouldAlign = false;
   if (lastLevel && lastLevel.details && details) {


### PR DESCRIPTION
### This PR will...
- Break fragment loading logic from `stream-controller` into `base-stream-controller`
- Reuse base fragment loading logic in `audio-stream-controller`
    - Fixes bugs related to live streams with alternate audio
- Simplify fragment loading logic by removing unnecessary code and bad assumptions
- Clear cached data in `tsdemuxer` when contiguity is broken
- Clear `currentTransmuxSession` in `transmuxer-interface` on `flush()` so that if the same fragment is consecutively reloaded, it does not cause dropped audio frames
    - I commonly saw this in backtracking scenarios
- Re-adds the `id` property to the SB, which was causing alt audio problems (see https://github.com/video-dev/hls.js/pull/2067)
- Ensure that streams start at `config.startPosition` if set

### Why is this Pull Request needed?
So that live streams with alternate audio play correctly. In the current branch, the audio track does not load fragments at the correct time, and playback cannot begin. This PR makes it so that the stream-controller and audio-stream-controller load fragments in the same way.

### Are there any points in the code the reviewer needs to double check?
More testing against streams with alt audio

### Resolves issues:
JW8-9842