### PR TITLE
Enable software AES if Web Crypto is not supported

### DIFF
--- a/src/crypt/decrypter.ts
+++ b/src/crypt/decrypter.ts
@@ -15,7 +15,7 @@ export default class Decrypter {
   private observer: any;
   private config: any;
   private removePKCS7Padding: boolean;
-  private subtle: boolean = false;
+  private subtle: any | null = null;
   private softwareDecrypter: AESDecryptor | null = null;
   private key: ArrayBuffer | null = null;
   private fastAesKey: FastAESKey | null = null;
@@ -33,6 +33,8 @@ export default class Decrypter {
         const browserCrypto = global.crypto;
         if (browserCrypto) {
           this.subtle = browserCrypto.subtle || browserCrypto.webkitSubtle;
+        } else {
+          this.config.enableSoftwareAES = true;
         }
       } catch (e) {}
     }


### PR DESCRIPTION
### Why is this Pull Request needed?
So that if WebCrypto is not supported by the browser, we will fall back to software AES decryption

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:

Part of JW8-9030