### PR TITLE
Improve AACDemuxer/MP3 Demuxer parsing behavior

### DIFF
--- a/src/demux/aacdemuxer.ts
+++ b/src/demux/aacdemuxer.ts
@@ -116,7 +116,7 @@ class AACDemuxer implements Demuxer {
         offset++;
       }
       // At end of fragment, if there is remaining data, append everything since last useable data to cache.
-      if (offset === length && lastDataIndex !== length) {
+      if (lastDataIndex !== length) {
           let partialData = data.slice(lastDataIndex);
           this.cachedData = appendUint8Array(this.cachedData, partialData);
       }

--- a/src/demux/aacdemuxer.ts
+++ b/src/demux/aacdemuxer.ts
@@ -70,9 +70,9 @@ class AACDemuxer implements Demuxer {
       data = appendUint8Array(this.cachedData, data);
       this.cachedData = new Uint8Array();
     }
-    let lastDataIndex;
     let id3Data = ID3.getID3Data(data, 0) || [];
     let offset = id3Data.length;
+    let lastDataIndex;
     let pts;
     const track = this._audioTrack;
     const id3Track = this._id3Track;
@@ -99,13 +99,13 @@ class AACDemuxer implements Demuxer {
           this.frameIndex++;
           pts = frame.sample.pts;
           offset += frame.length;
+          lastDataIndex = offset;
         } else {
           logger.log('Unable to parse AAC frame');
           let partialData = data.slice(offset);
 
           this.cachedData = appendUint8Array(this.cachedData, partialData);
           offset += partialData.length;
-          lastDataIndex = offset;
         }
       } else if (ID3.canParse(data, offset)) {
         id3Data = ID3.getID3Data(data, offset);

--- a/src/demux/mp3demuxer.ts
+++ b/src/demux/mp3demuxer.ts
@@ -84,6 +84,7 @@ class MP3Demuxer implements Demuxer {
           offset += frame.length;
           pts = frame.sample.pts;
           this.frameIndex++;
+          lastDataIndex = offset;
         } else {
           let partialData = data.slice(offset);
 
@@ -94,12 +95,17 @@ class MP3Demuxer implements Demuxer {
         id3Data = ID3.getID3Data(data, offset);
         id3Track.samples.push({ pts: pts, dts: pts, data: id3Data });
         offset += id3Data.length;
+        lastDataIndex = offset;
       } else {
         let partialData = data.slice(offset);
 
         this.cachedData = appendUint8Array(this.cachedData, partialData);
         offset += partialData.length;
       }
+      if (offset === length && lastDataIndex !== length) {
+        let partialData = data.slice(lastDataIndex);
+        this.cachedData = appendUint8Array(this.cachedData, partialData);
+    }
     }
 
     return {

--- a/src/demux/mp3demuxer.ts
+++ b/src/demux/mp3demuxer.ts
@@ -102,7 +102,7 @@ class MP3Demuxer implements Demuxer {
         this.cachedData = appendUint8Array(this.cachedData, partialData);
         offset += partialData.length;
       }
-      if (offset === length && lastDataIndex !== length) {
+      if (lastDataIndex !== length) {
         let partialData = data.slice(lastDataIndex);
         this.cachedData = appendUint8Array(this.cachedData, partialData);
     }

--- a/src/demux/mp3demuxer.ts
+++ b/src/demux/mp3demuxer.ts
@@ -62,6 +62,7 @@ class MP3Demuxer implements Demuxer {
 
     let id3Data = ID3.getID3Data(data, 0) || [];
     let offset = id3Data.length;
+    let lastDataIndex;
     let pts;
     const track = this._audioTrack;
     const id3Track = this._id3Track;


### PR DESCRIPTION
### This PR will...
Improve the caching algorithm. Will now keep track of the last index data was found, and properly increment, caching when there is remaining unused data at end of fragment. 

### Why is this Pull Request needed?
Starz streams where there are 10 additional bytes before the id3 header do not work in current implementation

### Are there any points in the code the reviewer needs to double check?
Is there a ticket for this bug?

### Resolves issues:

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
