### PR TITLE
Fix failed iteration over channels map when resetting the 608 parser JW8-9979

### DIFF
--- a/src/utils/cea-608-parser.js
+++ b/src/utils/cea-608-parser.js
@@ -1145,12 +1145,11 @@ class Cea608Parser {
      * Reset state of parser and its channels.
      */
   reset () {
-    for (let i = 0; i < this.channels.length; i++) {
+    for (let i = 0; i < Object.keys(this.channels).length; i++) {
       if (this.channels[i]) {
         this.channels[i].reset();
       }
     }
-
     this.cmdHistory = createCmdHistory();
   }
 


### PR DESCRIPTION
### This PR will...
- Call `Object.keys` before iterating over `this.channels`

### Why is this Pull Request needed?
So that channels are iterated over and cleared when the 608 parser is reset

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
Jw8-9979


