### PR TITLE
Remove SB from internal map synchronously with removal from MS JW8-9996

### DIFF
--- a/src/controller/buffer-controller.ts
+++ b/src/controller/buffer-controller.ts
@@ -161,6 +161,9 @@ export default class BufferController extends EventHandler {
           if (this.mediaSource) {
             this.mediaSource.removeSourceBuffer(sb);
           }
+          // Synchronously remove the SB from the map before the next call in order to prevent an async function from
+          // accessing it
+          this.sourceBuffer[type] = undefined;
         }
       } catch (err) {
         logger.warn(`Failed to reset the ${type} buffer`, err);


### PR DESCRIPTION
### This PR will...
Synchronously remove the SB from the internal map

### Why is this Pull Request needed?
There is a chance for another buffer operation to access the queue while the `onBufferReset()` handler is iterating through the SB map and removing SBs. This results in an "sourceBuffer has been removed from parent MediaSource" exception. By removing the SB synchronously we avoid this problem.

### Are there any points in the code the reviewer needs to double check?
No

### Resolves issues:
JW8-9996
