### PR TITLE
Only allocate dummyTrack once instead of per-call JW8-10107

### DIFF
--- a/src/demux/aacdemuxer.ts
+++ b/src/demux/aacdemuxer.ts
@@ -124,9 +124,9 @@ class AACDemuxer implements Demuxer {
 
     return {
       audioTrack: track,
-      avcTrack: dummyTrack(),
+      avcTrack: dummyTrack,
       id3Track,
-      textTrack: dummyTrack()
+      textTrack: dummyTrack
     };
   }
 
@@ -146,9 +146,9 @@ class AACDemuxer implements Demuxer {
     
     return {
       audioTrack: this._audioTrack,
-      avcTrack: dummyTrack(),
+      avcTrack: dummyTrack,
       id3Track: this._id3Track,
-      textTrack: dummyTrack()
+      textTrack: dummyTrack
     };
   }
 

--- a/src/demux/dummy-demuxed-track.ts
+++ b/src/demux/dummy-demuxed-track.ts
@@ -1,6 +1,6 @@
 import { DemuxedTrack } from '../types/demuxer';
 
-export const dummyTrack = () : DemuxedTrack => ({
+export const dummyTrack: DemuxedTrack = Object.freeze({
   type: '',
   id: -1,
   pid: -1,

--- a/src/demux/dummy-demuxed-track.ts
+++ b/src/demux/dummy-demuxed-track.ts
@@ -1,6 +1,6 @@
 import { DemuxedTrack } from '../types/demuxer';
 
-export const dummyTrack: DemuxedTrack = Object.freeze({
+export const dummyTrack: DemuxedTrack = {
   type: '',
   id: -1,
   pid: -1,
@@ -8,4 +8,4 @@ export const dummyTrack: DemuxedTrack = Object.freeze({
   sequenceNumber: -1,
   samples: [],
   dropped: 0
-});
+};

--- a/src/demux/mp3demuxer.ts
+++ b/src/demux/mp3demuxer.ts
@@ -110,9 +110,9 @@ class MP3Demuxer implements Demuxer {
 
     return {
       audioTrack: track,
-      avcTrack: dummyTrack(),
+      avcTrack: dummyTrack,
       id3Track,
-      textTrack: dummyTrack()
+      textTrack: dummyTrack
     };
   }
 
@@ -132,9 +132,9 @@ class MP3Demuxer implements Demuxer {
     
     return {
       audioTrack: this._audioTrack,
-      avcTrack: dummyTrack(),
+      avcTrack: dummyTrack,
       id3Track: this._id3Track,
-      textTrack: dummyTrack()
+      textTrack: dummyTrack
     };
   }
 

--- a/src/demux/mp4demuxer.ts
+++ b/src/demux/mp4demuxer.ts
@@ -35,28 +35,28 @@ class MP4Demuxer implements Demuxer {
     // that the fetch loader gives us flush moof+mdat pairs. If we push jagged data to MSE, it will throw an exception.
     const segmentedData = segmentValidRange(avcSamples);
     this.remainderData = segmentedData.remainder;
-    const avcTrack = dummyTrack();
+    const avcTrack = dummyTrack;
     avcTrack.samples = segmentedData.valid;
 
     return {
-      audioTrack: dummyTrack(),
+      audioTrack: dummyTrack,
       avcTrack,
-      id3Track: dummyTrack(),
-      textTrack: dummyTrack()
+      id3Track: dummyTrack,
+      textTrack: dummyTrack
     };
   }
 
   // TODO: Re-validate remainder data? Or we can assume that the segmented remainder is always valid CMAF
   flush () {
-    const avcTrack: DemuxedTrack = dummyTrack();
+    const avcTrack: DemuxedTrack = dummyTrack;
     avcTrack.samples = this.remainderData;
     this.remainderData = null;
 
     return {
-        audioTrack: dummyTrack(),
+        audioTrack: dummyTrack,
         avcTrack,
-        id3Track: dummyTrack(),
-        textTrack: dummyTrack()
+        id3Track: dummyTrack,
+        textTrack: dummyTrack
     };
   }
 

--- a/src/remux/mp4-remuxer.ts
+++ b/src/remux/mp4-remuxer.ts
@@ -762,9 +762,9 @@ function dropSamplesUntilKeyframe (track: DemuxedTrack) : number {
     }
     dropIndex++;
   }
-  track.dropped += dropIndex;
   if (dropIndex) {
     track.samples = samples.slice(dropIndex);
+    track.dropped += dropIndex;
   }
   return dropIndex;
 }


### PR DESCRIPTION
### Why is this Pull Request needed?
To improve performance; by avoid re-allocations we avoid GC events in the future

### Are there any points in the code the reviewer needs to double check?
Need to make sure that we're not changing props on dummy tracks, since it's frozen. Automation should reveal this

### Resolves issues:
JW8-10107
