### PR TITLE
TS the ABR controller

### DIFF
--- a/src/controller/stream-controller.ts
+++ b/src/controller/stream-controller.ts
@@ -227,19 +227,17 @@ export default class StreamController extends BaseStreamController {
     this.hls.trigger(Event.KEY_LOADING, { frag });
   }
 
-  _loadFragment (frag) {
+  _loadFragment (frag: Fragment) {
     // Check if fragment is not loaded
     const fragState = this.fragmentTracker.getState(frag);
     this.fragCurrent = frag;
     // Don't update nextLoadPosition for fragments which are not buffered
-    if (Number.isFinite(frag.sn) && !this.bitrateTest) {
+    if (Number.isFinite(frag.sn as number) && !this.bitrateTest) {
       this.nextLoadPosition = frag.start + frag.duration;
     }
 
     // Allow backtracked fragments to load
     if (frag.backtracked || fragState === FragmentState.NOT_LOADED || fragState === FragmentState.PARTIAL) {
-      frag.autoLevel = this.hls.autoLevelEnabled;
-
       if (frag.sn === 'initSegment') {
         this._loadInitSegment(frag);
       } else if (this.bitrateTest) {

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -85,6 +85,8 @@ export default class Fragment {
   public urlId: number = 0;
   // TODO: Create InitSegment class extended from Fragment
   public data?: ArrayBuffer;
+  // A flag indicating whether the segment was downloaded in order to test bitrate, and was not buffered
+  public bitrateTest: boolean = false;
 
   // setByteRange converts a EXT-X-BYTERANGE attribute into a two element array
   setByteRange (value: string, previousFrag?: Fragment) {

--- a/src/loader/load-stats.ts
+++ b/src/loader/load-stats.ts
@@ -10,4 +10,5 @@ export default class LoadStats implements LoaderStats {
   total: number = 0;
   tparsed: number = 0;
   trequest: number = 0;
+  bwEstimate: number = 0;
 }

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -54,7 +54,9 @@ export interface LoaderStats {
   // number of retries attempted
   retry: number,
   // the request was cancelled or timed out
-  aborted: boolean
+  aborted: boolean,
+  // The bandwidth estimate recorded while the download was occurring
+  bwEstimate: number
 }
 
 type LoaderOnSuccess < T extends LoaderContext > = (


### PR DESCRIPTION
### This PR will...
- TS the ABR controller
- Fix errors called out by TS:
    - `stats.bw` does not exist; it's actually `stats.bwEstimate`
    - Add `bwEstimate` to the loader object
    - Add `bitrateTest` to the frag object
- Refactor `_abandonRulesCheck` for readability

### Why is this Pull Request needed?
So that the ABR controller is neater, can be statically analyzed, and refactored easily in the future (specifically for the upcoming stats refactor)

### Are there any points in the code the reviewer needs to double check?
Playing around with ABR would be good if you have the time. I tested up and downswitching via the network tab but another set of eyes would be good
