### PR TITLE
Enforce minimum chunk size of 16kb

### DIFF
--- a/src/demux/chunk-cache.ts
+++ b/src/demux/chunk-cache.ts
@@ -7,11 +7,11 @@ export default class ChunkCache {
     this.dataLength += chunk.length;
   }
 
-  flush (): Uint8Array | null {
+  flush (): Uint8Array {
     const { chunks, dataLength } = this;
     let result;
     if (!chunks.length) {
-      return null
+      return new Uint8Array(0);
     } else if (chunks.length === 1) {
       result = chunks[0];
     } else {

--- a/src/demux/transmuxer.ts
+++ b/src/demux/transmuxer.ts
@@ -123,8 +123,8 @@ export default class Transmuxer {
 
     let { demuxer, remuxer } = this;
     if (this.needsProbing(uintData, discontinuity, trackSwitch)) {
-      const cachedData = cache.flush();
-      if (cachedData) {
+      if (cache.dataLength) {
+        const cachedData = cache.flush();
         uintData = appendUint8Array(cachedData, uintData);
       }
       ({ demuxer, remuxer } = this.configureTransmuxer(uintData, transmuxConfig));

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -53,7 +53,8 @@ export default class FragmentLoader {
       timeout: config.fragLoadingTimeOut,
       maxRetry: 0,
       retryDelay: 0,
-      maxRetryDelay: config.fragLoadingMaxRetryTimeout
+      maxRetryDelay: config.fragLoadingMaxRetryTimeout,
+      highWaterMark: Math.pow(2, 14) // 16kb
     };
 
     return new Promise((resolve, reject) => {

--- a/src/loader/fragment-loader.ts
+++ b/src/loader/fragment-loader.ts
@@ -9,6 +9,8 @@ import {
     LoaderCallbacks
 } from '../types/loader';
 
+const MIN_CHUNK_SIZE = Math.pow(2, 14); // 16kb
+
 export default class FragmentLoader {
   private config: any;
   private loader: Loader<FragmentLoaderContext> | null = null;
@@ -54,7 +56,7 @@ export default class FragmentLoader {
       maxRetry: 0,
       retryDelay: 0,
       maxRetryDelay: config.fragLoadingMaxRetryTimeout,
-      highWaterMark: Math.pow(2, 14) // 16kb
+      highWaterMark: MIN_CHUNK_SIZE
     };
 
     return new Promise((resolve, reject) => {

--- a/src/loader/playlist-loader.ts
+++ b/src/loader/playlist-loader.ts
@@ -259,7 +259,8 @@ class PlaylistLoader extends EventHandler {
       timeout,
       maxRetry,
       retryDelay,
-      maxRetryDelay
+      maxRetryDelay,
+      highWaterMark: 0
     };
 
     const loaderCallbacks = {

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -28,6 +28,8 @@ export interface LoaderConfiguration {
   retryDelay: number
   // max connection retry delay (ms)
   maxRetryDelay: number
+  // When streaming progressively, this is the minimum chunk size required to emit a PROGRESS event
+  highWaterMark: number
 }
 
 export interface LoaderResponse {
@@ -69,7 +71,7 @@ type LoaderOnSuccess < T extends LoaderContext > = (
   networkDetails: any
 ) => void;
 
-type LoaderOnProgress < T extends LoaderContext > = (
+export type LoaderOnProgress < T extends LoaderContext > = (
   stats: LoaderStats,
   context: T,
   data: string | ArrayBuffer,

--- a/src/utils/chunker.ts
+++ b/src/utils/chunker.ts
@@ -1,0 +1,41 @@
+import { appendUint8Array } from './mp4-tools';
+
+export default class Chunker {
+  private chunkSize: number;
+  public cache: Uint8Array | null = null;
+  constructor (chunkSize = Math.pow(2, 19)) {
+    this.chunkSize = chunkSize;
+  }
+
+  public push (data: Uint8Array) : Array<Uint8Array> {
+    const { cache, chunkSize } = this;
+    const result: Array<Uint8Array> = [];
+
+    let temp: Uint8Array | null = null;
+    if (cache && cache.length) {
+      temp = appendUint8Array(cache, data);
+      this.cache = null;
+    } else {
+      temp = data;
+    }
+
+    if (temp.length < chunkSize) {
+      this.cache = temp;
+      return result;
+    }
+
+    if (temp.length > chunkSize) {
+      let offset = 0;
+      let len = temp.length;
+      while (offset < (len - chunkSize)) {
+        result.push(temp.slice(offset, offset + chunkSize));
+        offset += chunkSize;
+      }
+      this.cache = temp.slice(offset);
+    } else {
+      result.push(temp);
+    }
+
+    return result;
+  }
+}


### PR DESCRIPTION
### This PR will...
Set a highWaterMark of 16kb (2^14) when using the progressive fetch loader for fragment loading

### Why is this Pull Request needed?
Small chunks are inefficient to load; the scheduling overhead for handling these chunks is greater than the benefit of buffering them immediately

### Are there any points in the code the reviewer needs to double check?
Should I add a top-level config value for setting the chunk size

### Resolves issues:
JW8-10512

