### PR TITLE
Polyfill uint8array slice JW8-9030

### DIFF
--- a/src/demux/transmuxer-worker.ts
+++ b/src/demux/transmuxer-worker.ts
@@ -1,7 +1,4 @@
-/* transmuxer web worker.
- *  - listen to worker message, and trigger DemuxerInline upon reception of Fragments.
- *  - provides MP4 Boxes back to main thread using [transferable objects](https://developers.google.com/web/updates/2011/12/Transferable-Objects-Lightning-Fast) in order to minimize message passing overhead.
- */
+import '../polyfills/runtime-polyfills';
 
 import Transmuxer from '../demux/transmuxer';
 import Event from '../events';

--- a/src/hls.js
+++ b/src/hls.js
@@ -1,3 +1,5 @@
+import { polyfillSlice } from './polyfills/runtime-polyfills';
+polyfillSlice();
 import * as URLToolkit from 'url-toolkit';
 
 import {

--- a/src/hls.js
+++ b/src/hls.js
@@ -1,5 +1,4 @@
-import { polyfillSlice } from './polyfills/runtime-polyfills';
-polyfillSlice();
+import './polyfills/runtime-polyfills';
 import * as URLToolkit from 'url-toolkit';
 
 import {

--- a/src/polyfills/runtime-polyfills.ts
+++ b/src/polyfills/runtime-polyfills.ts
@@ -1,9 +1,7 @@
-export function polyfillSlice() {
-  if (!Uint8Array.prototype.slice) {
-    Object.defineProperty(Uint8Array.prototype, 'slice', {
-      value: function (begin, end) {
-        return new Uint8Array(Array.prototype.slice.call(this, begin, end));
-      }
-    });
-  }
+if (!Uint8Array.prototype.slice) {
+  Object.defineProperty(Uint8Array.prototype, 'slice', {
+    value: function (begin, end) {
+      return new Uint8Array(Array.prototype.slice.call(this, begin, end));
+    }
+  });
 }

--- a/src/polyfills/runtime-polyfills.ts
+++ b/src/polyfills/runtime-polyfills.ts
@@ -1,0 +1,9 @@
+export function polyfillSlice() {
+  if (!Uint8Array.prototype.slice) {
+    Object.defineProperty(Uint8Array.prototype, 'slice', {
+      value: function (begin, end) {
+        return new Uint8Array(Array.prototype.slice.call(this, begin, end));
+      }
+    });
+  }
+}


### PR DESCRIPTION
### Why is this Pull Request needed?
`Uint8Array.slice` is not supported in old browsers which have been previously supported by Hls.js. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice#Browser_compatibility

### Are there any points in the code the reviewer needs to double check?
Should we also polyfill Int32/Int16/etc. arrays?

### Resolves issues:
JW8-9030
