### PR TITLE
[JW8-10633] Prevent the use of Array methods not available in IE11

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,7 +70,10 @@ module.exports = {
       1,
       'never'
     ],
-
+    'no-restricted-properties': [2,
+      { 'property': 'findIndex' },  // Intended to block usage of Array.prototype.findIndex
+      { 'property': 'find' }        // Intended to block usage of Array.prototype.find
+    ],
     'standard/no-callback-literal': 1,
     'import/first': 1,
     'no-var': 1,

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -411,9 +411,14 @@ export default class LevelController extends EventHandler {
     if (!currentLevel) {
       return;
     }
-
     if (currentLevel.audioGroupIds) {
-      const urlId = currentLevel.audioGroupIds.findIndex((groupId) => groupId === audioGroupId);
+      let urlId = -1;
+      currentLevel.audioGroupIds.some((groupId, i) => {
+        if (groupId === audioGroupId) {
+          urlId = i;
+          return true;
+        }
+      });
       if (urlId !== currentLevel.urlId) {
         currentLevel.urlId = urlId;
         this.startLoad();

--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -258,7 +258,13 @@ class TimelineController extends EventHandler {
         this.tracks.forEach((track, index) => {
           let textTrack;
           if (index < inUseTracks.length) {
-            const inUseTrack = [].slice.call(inUseTracks).find(inUseTrack => canReuseVttTextTrack(inUseTrack, track));
+            let inUseTrack = null;
+            for (let i = 0; i < inUseTracks.length; i++) {
+              if (canReuseVttTextTrack(inUseTracks[i], track)) {
+                inUseTrack = inUseTracks[i];
+                break;
+              }
+            }
             // Reuse tracks with the same label, but do not reuse 608/708 tracks
             if (inUseTrack) {
               textTrack = inUseTrack;


### PR DESCRIPTION
### This PR will...
Prevent the use of Array methods not available in IE11

### Why is this Pull Request needed?
So that our player can play HLS streams with audio and text tracks in IE11


JW8-10633