### PR TITLE
[JW8-11130] Fix non-native track selectopm

### DIFF
--- a/src/controller/subtitle-track-controller.js
+++ b/src/controller/subtitle-track-controller.js
@@ -220,7 +220,7 @@ class SubtitleTrackController extends EventHandler {
 
   _onTextTracksChanged () {
     // Media is undefined when switching streams via loadSource()
-    if (!this.media) {
+    if (!this.media || !this.hls.config.renderTextTracksNatively) {
       return;
     }
 


### PR DESCRIPTION
#256 # This PR will...
Ignore native text track changes when `renderTextTracksNatively` is set to `false`

### Why is this Pull Request needed?
This block from our fork needed to be upstreamed so that changed to media textTracks does not trigger a change in the track controller that could prevent the selected track from loading.

### Resolves issues:
JW8-11130

### Checklist

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] API or design changes are documented in API.md
